### PR TITLE
fix container process addr symbolizatio

### DIFF
--- a/profile-bee/src/symbols.rs
+++ b/profile-bee/src/symbols.rs
@@ -268,26 +268,16 @@ impl StackFrameInfo {
         let object_key = (self.ns.unwrap_or(self.pid as u64), object_path.into());
 
         let obj_cache = finder.obj_cache.entry(object_key).or_insert_with(|| {
-            let path = object_path.to_str().unwrap_or_default();
+            let mut path = object_path.to_str().unwrap_or_default();
             if path == "[vdso]" || path.starts_with('[') {
                 // since this is a cache entry, should prevent much reloading
                 return None;
             }
-
+            if let Some(striped) = path.strip_suffix(" (deleted)") {
+                path = striped; // try best if meet a deleted dso
+            }
             // read root path
-            let root_link = format!("/proc/{}/root", id);
-            let base = Path::new(&root_link);
-            let mut target = match read_link(&base) {
-                Ok(link) => link,
-                Err(_e) => {
-                    // println!("Can't read link {root_link}. Process  {path:?} might have terminated. - {e:?}");
-                    // Best attempt, use root
-                    PathBuf::new()
-                }
-            };
-
-            target.push(path);
-
+            let target = PathBuf::from(format!("/proc/{}/root{}", id, path));
             // let file = File::open(&target);
             // TODO use mmap if dealing with large files eg. let mmapped_file = unsafe { Mmap::map(&file) };
 


### PR DESCRIPTION
Hey, I found some mistakes when I explored this repo. It cannot locate elfs inside a container when symbolizing a container process. I did this pr to fix it (not quite sure if it works for all scenarios)