### PR TITLE
feat: interactive TUI flamegraph viewer via flamelens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,55 @@ More documentation in [docs](docs) directory.
 - A SVG flamegraph (generated with inferno) you can load in your browser
 - [Branden Gregg's](https://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html) Stack Collapsed [format](https://github.com/BrendanGregg/flamegraph#2-fold-stacks) that can be loaded up using [speedscope visualizer](https://www.speedscope.app/)
 - D3 flamegraph JSON and static HTML output
+- Interactive terminal UI (TUI) viewer powered by [flamelens](https://github.com/YS-L/flamelens)
 - Your own custom format
+
+### Viewing Options
+
+Profile-bee offers multiple ways to view profiling results:
+
+#### 1. Static Files
+Generate standard profiling output formats:
+```bash
+# SVG flamegraph (via inferno)
+profile-bee --svg profile.svg --cmd "my-app" --time 5000
+
+# Collapsed stacks (for speedscope.app)
+profile-bee --collapse profile.txt --time 5000
+
+# D3 flamegraph (HTML + JSON)
+profile-bee --html profile.html --json profile.json --time 5000
+```
+
+#### 2. Web Browser (Live Updates)
+Real-time flamegraph updates served via HTTP:
+```bash
+profile-bee --serve --stream-mode 1 --time 30000
+# Open http://localhost:8000 and click "realtime-updates"
+```
+
+#### 3. Terminal UI (Interactive)
+View flamegraph directly in your terminal:
+```bash
+# Static: View after profiling completes
+profile-bee --tui --cmd "my-app" --time 5000
+
+# Live: Watch flamegraph update in real-time
+profile-bee --tui --stream-mode 1 --time 30000
+
+# Combo: TUI + Web server (share with team while viewing locally)
+profile-bee --tui --serve --stream-mode 1 --time 30000
+```
+
+**TUI Controls:**
+- `hjkl` or arrow keys: Navigate flamegraph
+- `Enter`: Zoom into selected frame
+- `Esc`: Reset zoom to full view
+- `/regex`: Search and highlight matching frames
+- `#`: Highlight selected frame
+- `n` / `N`: Jump to next/previous match
+- `z`: Freeze/unfreeze updates (live mode)
+- `q`: Quit viewer
 
 ### Stack unwinding, Symbolization and Debug info
 
@@ -121,6 +169,7 @@ profile-bee --svg output.svg -- ./my-optimized-binary
 ### Features
 - **DWARF-based stack unwinding** (enabled by default) for profiling binaries without frame pointers
 - Frame pointer-based unwinding in eBPF for maximum performance
+- **Interactive terminal UI viewer** powered by flamelens - no browser required
 - Rust and C++ symbols demangling supported (via gimli/blazesym)
 - Some source mapping supported
 - Simple symbol lookup cache
@@ -131,7 +180,7 @@ profile-bee --svg output.svg -- ./my-optimized-binary
 - Profile target PIDs, CPU id, or itself
 - **Automatic termination** when target PID (via `--pid`) or spawned process (via `--cmd`) exits
 - Static d3 flamegraph JSON and/or HTML output
-- Real time flamegraphs served over integrated web server (using warp)
+- Real time flamegraphs (both terminal UI and web-based) with live updates
 
 ### Limitations
 - Linux only

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -73,10 +73,22 @@ The vendored `cargo-trace` already has some of this plumbing. The main work is w
 
 ## Integrations
 
-### flamelens
+### flamelens ✅ Integrated
 
-[flamelens](https://github.com/YS-L/flamelens) is an interactive TUI flamegraph viewer. Profile-bee's collapsed stack output is already compatible. Ideas:
+[flamelens](https://github.com/YS-L/flamelens) is now embedded as profile-bee's terminal UI viewer.
 
-- Pipe directly: `sudo profile-bee -p 1234 | flamelens`
-- Add a `--flamelens` flag that pipes output to flamelens automatically (if installed)
-- Explore embedding flamelens as an optional feature for an integrated TUI experience
+Usage:
+- **Static mode:** `profile-bee --tui --cmd "app" --time 5000`
+  - Profile runs, then shows interactive flamegraph in terminal
+- **Live mode:** `profile-bee --tui --stream-mode 1 --time 30000`
+  - Real-time flamegraph updates every 500ms
+  - Press `z` to freeze/unfreeze, `q` to exit
+- **Dual mode:** `profile-bee --tui --serve --stream-mode 1`
+  - TUI displays locally, web server at http://localhost:8000 for sharing
+
+Benefits:
+- No browser required for quick profiling sessions
+- All the power of interactive flamegraph navigation (zoom, search, filter)
+- Self-contained: single binary includes profiler + viewer
+- Can run both TUI and web server simultaneously
+

--- a/profile-bee/Cargo.toml
+++ b/profile-bee/Cargo.toml
@@ -37,6 +37,7 @@ gimli = "0.31.1"
 object = "0.37.0"
 libc = "0.2.86"
 procmaps = "0.4.1"
+flamelens = { path = "../flamelens", default-features = false }
 
 [[bin]]
 name = "profile-bee"


### PR DESCRIPTION
### update: approach dropped for #37

One option for #8 

Embed flamelens as an optional terminal UI for viewing flamegraphs directly in the terminal, no browser required.

Modes:
- Static: --tui shows interactive flamegraph after profiling completes
- Live: --tui --stream-mode 1 streams real-time updates to the viewer
- Dual: --tui --serve runs both TUI and web server simultaneously

Adds --tui CLI flag, TTY detection, and flamelens dependency. Updates README with viewing options, TUI controls, and usage examples.

Note: requires an upstream patch to flamelens to expose library APIs (run_from_collapsed_stacks, run_from_live_stream) for embedding. Currently using a local path dependency pending upstream acceptance.

<img width="1042" height="766" alt="SCR-20260209-hviv" src="https://github.com/user-attachments/assets/3e1c6483-3b91-49f2-8a46-4de256b0613c" />

(profiler profiled)
<img width="1043" height="723" alt="SCR-20260209-hvln" src="https://github.com/user-attachments/assets/7a444868-920e-4f92-bb2b-4a72ff06cd44" />

```bash
# load
seq 10 | xargs -P0 -n1 timeout 50 yes > /dev/null

# tui
sudo ./target/release/profile-bee --dwarf=true --tui --stream-mode 1
```

flamelens dependency is: https://github.com/YS-L/flamelens/pull/15