### PR TITLE
feat: enhance uprobe support with flexible configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ profile-bee --kprobe vfs_write --time 200 --svg kprobe.svg
 # Profile using a tracepoint over a interval of 200ms
 profile-bee --tracepoint tcp:tcp_probe --time 200 --svg tracepoint.svg
 
+# Profile using uprobe on malloc in libc
+profile-bee --uprobe malloc --time 1000 --svg malloc.svg
+
+# Profile uprobe on a specific binary with custom path
+profile-bee --uprobe my_function --uprobe-path /path/to/binary --time 1000 --svg uprobe.svg
+
+# Profile using uprobe on a library name (e.g., libpthread)
+profile-bee --uprobe pthread_create --uprobe-path libpthread --time 1000 --svg thread.svg
+
+# Profile uprobe with function offset
+profile-bee --uprobe my_function+16 --uprobe-path /path/to/binary --time 1000 --svg uprobe_offset.svg
+
+# Profile using uretprobe (return probe) on malloc
+profile-bee --uprobe malloc --uretprobe --time 1000 --svg malloc_ret.svg
+
+# Profile uprobe for a specific PID only
+profile-bee --uprobe malloc --uprobe-pid 12345 --time 1000 --svg malloc_pid.svg
+
 # Profile specific pid (includes child processes, automatically stops when process exits)
 profile-bee --pid <pid> --svg output.svg --time 10000
 
@@ -171,7 +189,8 @@ The TUI viewer is optional and can be enabled with the `tui` feature flag. See [
 - Simple symbol lookup cache
 - SVG Flamegraph generation (via inferno)
 - BPF based stacktrace aggregation for reducing kernel <-> userspace transfers
-- Basic Kernel and tracepoint probing
+- **User space probing (uprobe/uretprobe)** - trace any userspace function
+- Basic Kernel probing (kprobe) and tracepoint support
 - Group by CPUs
 - Profile target PIDs, CPU id, or itself
 - **Automatic termination** when target PID (via `--pid`) or spawned process (via `--cmd`) exits
@@ -188,10 +207,11 @@ The TUI viewer is optional and can be enabled with the `tui` feature flag. See [
 ### TODOs
 - Optimize CPU usage
 - Check stack correctness (compare with perf, pprof etc)
-- implement uprobing/USDT
+- Implement USDT (User Statically-Defined Tracing) support
 - pid nesting
 - Off CPU profiling
 - Publish to crates.io
+- ~~Implement uprobing (uprobe/uretprobe)~~
 - ~~Optimize symbol lookup via binary search~~
 - ~~Measure cache hit ratio~~
 - ~~Missing symbols~~

--- a/profile-bee-ebpf/src/main.rs
+++ b/profile-bee-ebpf/src/main.rs
@@ -2,10 +2,10 @@
 #![no_main]
 
 use aya_ebpf::{
-    macros::{kprobe, uprobe},
+    macros::{kprobe, uprobe, uretprobe},
     macros::{perf_event, tracepoint},
-    programs::ProbeContext,
     programs::{PerfEventContext, TracePointContext},
+    programs::{ProbeContext, RetProbeContext},
 };
 use profile_bee_ebpf::collect_trace;
 
@@ -26,6 +26,12 @@ pub fn kprobe_profile(ctx: ProbeContext) -> u32 {
 
 #[uprobe]
 pub fn uprobe_profile(ctx: ProbeContext) -> u32 {
+    unsafe { collect_trace(ctx) }
+    0
+}
+
+#[uretprobe]
+pub fn uretprobe_profile(ctx: RetProbeContext) -> u32 {
     unsafe { collect_trace(ctx) }
     0
 }


### PR DESCRIPTION
Add comprehensive uprobe/uretprobe support with the following improvements:

- Add CLI arguments for uprobe customization:
  - --uprobe-path: Specify target binary/library (absolute path or name)
  - --uretprobe: Enable return probe mode
  - --uprobe-pid: Attach to specific process
  - Support function+offset syntax (e.g., malloc+16)

- Introduce UProbeConfig struct for better configuration management:
  - function: Function name with optional offset
  - path: Binary/library path (defaults to 'libc')
  - is_retprobe: Return probe flag
  - pid: Optional PID filter

- Add uretprobe eBPF program using RetProbeContext

- Update documentation with 7 new usage examples

- Fix CLI short option conflict (remove -c from --cmd)

This change replaces the previous hard-coded libc-only uprobe support with a flexible system that can trace any userspace function in any binary or library, with optional PID filtering and offset support.

USDT support remains for future implementation.

addresses #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added examples demonstrating uprobe/uretprobe profiling (malloc, specific binaries, library probes, function offsets, PID filtering)
  * Reworded features to highlight user-space probing and updated TODOs and descriptions

* **New Features**
  * Added support for return probes (uretprobe) to profile function exits
  * Uprobe configuration now supports target path, function(+offset), PID filtering, and return-probe selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->