### PR TITLE
feat(dwarf): replace individual shard maps with ArrayOfMaps

### DIFF
--- a/profile-bee-common/src/lib.rs
+++ b/profile-bee-common/src/lib.rs
@@ -116,10 +116,15 @@ pub const LEGACY_MAX_DWARF_STACK_DEPTH: usize = 21;
 
 pub const MAX_PROC_MAPS: usize = 8;
 
-/// Number of per-binary Array shard maps in eBPF (shard_0 .. shard_7)
-pub const MAX_UNWIND_SHARDS: usize = 8;
-/// Maximum unwind entries per shard (2^16, covered by 16 binary search iterations)
-pub const MAX_SHARD_ENTRIES: u32 = 65_536;
+/// Maximum number of inner shard maps in the outer ArrayOfMaps.
+/// With array-of-maps, unused slots cost nothing (no pre-allocated kernel memory).
+pub const MAX_UNWIND_SHARDS: usize = 64;
+/// Maximum unwind entries per inner shard map.
+/// With array-of-maps, each inner map is sized to the actual binary's table,
+/// but we need an upper bound for the binary search depth (17 iterations covers 2^17 = 128K).
+pub const MAX_SHARD_ENTRIES: u32 = 131_072;
+/// Binary search iterations needed: ceil(log2(MAX_SHARD_ENTRIES)) = 17
+pub const MAX_BIN_SEARCH_DEPTH: u32 = 17;
 /// Sentinel value: no shard assigned to this mapping
 pub const SHARD_NONE: u8 = 0xFF;
 

--- a/profile-bee-ebpf/Cargo.toml
+++ b/profile-bee-ebpf/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aya-ebpf = "0.1.1"
-aya-log-ebpf = "0.1.0"
+aya-ebpf = { git = "https://github.com/zz85/aya", branch = "array-of-maps" }
+aya-log-ebpf = { git = "https://github.com/zz85/aya", branch = "array-of-maps" }
 profile-bee-common = { path = "../profile-bee-common" }
 
 [[bin]]

--- a/profile-bee/Cargo.toml
+++ b/profile-bee/Cargo.toml
@@ -18,8 +18,8 @@ include = [
 ]
 
 [dependencies]
-aya = { version = ">=0.11", features=["async_tokio"] }
-aya-log = "0.2.1"
+aya = { git = "https://github.com/zz85/aya", branch = "array-of-maps" }
+aya-log = { git = "https://github.com/zz85/aya", branch = "array-of-maps" }
 profile-bee-common = { version = "0.1.0", path = "../profile-bee-common", features=["user"] }
 profile-bee-tui = { version = "0.1.0", path = "../profile-bee-tui", optional = true }
 anyhow = "1.0.42"


### PR DESCRIPTION
Replace the 8 individual shard_0..shard_7 eBPF Array maps with a single BPF_MAP_TYPE_ARRAY_OF_MAPS (unwind_shards), enabling dynamic inner map management from userspace.

Motivation:
- The old 8-shard / 65K-entry-per-shard design limited DWARF unwinding to 8 unique binaries and truncated large unwind tables (e.g. glibc).
- ArrayOfMaps allows up to 64 binaries with up to 131K entries each.
- Inner maps are created on-demand — unused slots cost no kernel memory.

eBPF side (profile-bee-ebpf):
- Replace shard_0..shard_7 static Array maps with a single UNWIND_SHARDS ArrayOfMaps, using the new aya-ebpf ArrayOfMaps type.
- shard_lookup() now does two bpf_map_lookup_elem calls (outer then inner) instead of an 8-way static match.
- MAX_BIN_SEARCH_DEPTH moved to profile-bee-common (was a local const).

Userspace (profile-bee):
- load_shard() creates inner maps via raw bpf() syscall and inserts them into the outer ArrayOfMaps using BPF_MAP_UPDATE_ELEM with fd-as-value.
- Inner maps use fixed max_entries=MAX_SHARD_ENTRIES (131072) to satisfy kernel <5.14 which requires exact max_entries match with the template. A TODO documents the future optimization for 5.14+ kernels.
- apply_dwarf_refresh() (background DWARF table loader) updated to use the same ArrayOfMaps insertion path.
- DwarfUnwindManager.binary_tables changed from HashMap<u8, Vec> to Vec<Vec> for O(1) shard access and natural limit enforcement.
- Oversized unwind tables are now truncated instead of skipped entirely.
- DWARF refresh and truncation logs moved to debug/tracing to avoid interfering with TUI mode.

Shared constants (profile-bee-common):
- MAX_UNWIND_SHARDS: 8 -> 64
- MAX_SHARD_ENTRIES: 65,536 -> 131,072
- New: MAX_BIN_SEARCH_DEPTH = 17 (ceil(log2(131072)))

Dependencies:
- aya/aya-ebpf: switched to github.com/zz85/aya branch array-of-maps which adds BPF_MAP_TYPE_ARRAY_OF_MAPS support to aya.

All 14 e2e tests pass (FP baseline, DWARF unwinding, shared library, PIE, Rust binary, deep stacks, comparison tests).

addresses #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Increased maximum shard configuration from 8 to 64 and per-shard capacity to improve profiling scalability and throughput.
  * Restructured internal data organization to support more flexible and efficient unwind table management.

* **Chores**
  * Updated dependencies to use forked versions supporting array-of-maps architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->