### PR TITLE
feat: bump MAX_UNWIND_SHARDS from 64 to 512, widen shard_id u8 → u16

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ sudo tests/run_e2e.sh --filter dwarf
 |---|---|---|
 | Max frame depth | 165 (tail-call) / 21 (legacy) | Kernel 33 tail-call limit; legacy for kprobe/uprobe |
 | Mappings per process | 8 (`MAX_PROC_MAPS`) | eBPF array size limit |
-| Unwind shards | 8 (`MAX_UNWIND_SHARDS`) | Max 8 unique binaries with tables loaded |
+| Unwind shards | 512 (`MAX_UNWIND_SHARDS`) | Max unique binaries with DWARF tables loaded |
 | Entries per shard | 65,536 (`MAX_SHARD_ENTRIES`) | Very large binaries truncated |
 | CFA registers | RSP, RBP only | Other registers skipped |
 | DWARF expressions | Unsupported | Except PLT-stub and signal-frame patterns |

--- a/profile-bee-common/src/lib.rs
+++ b/profile-bee-common/src/lib.rs
@@ -122,7 +122,7 @@ pub const MAX_PROC_MAPS: usize = 8;
 
 /// Maximum number of inner shard maps in the outer ArrayOfMaps.
 /// With array-of-maps, unused slots cost nothing (no pre-allocated kernel memory).
-pub const MAX_UNWIND_SHARDS: usize = 64;
+pub const MAX_UNWIND_SHARDS: usize = 512;
 /// Maximum unwind entries per inner shard map.
 /// With array-of-maps, each inner map is sized to the actual binary's table,
 /// but we need an upper bound for the binary search depth (17 iterations covers 2^17 = 128K).
@@ -130,7 +130,7 @@ pub const MAX_SHARD_ENTRIES: u32 = 131_072;
 /// Binary search iterations needed: ceil(log2(MAX_SHARD_ENTRIES)) = 17
 pub const MAX_BIN_SEARCH_DEPTH: u32 = 17;
 /// Sentinel value: no shard assigned to this mapping
-pub const SHARD_NONE: u8 = 0xFF;
+pub const SHARD_NONE: u16 = 0xFFFF;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(C)]
@@ -145,8 +145,8 @@ pub struct ExecMapping {
     pub begin: u64,
     pub end: u64,
     pub load_bias: u64,
-    pub shard_id: u8, // Which shard Array to search (0..MAX_UNWIND_SHARDS-1, or SHARD_NONE)
-    pub _pad1: [u8; 3],
+    pub shard_id: u16, // Which shard Array to search (0..MAX_UNWIND_SHARDS-1, or SHARD_NONE)
+    pub _pad1: [u8; 2],
     pub table_count: u32, // Number of entries in this shard for this binary
 }
 

--- a/profile-bee-ebpf/src/lib.rs
+++ b/profile-bee-ebpf/src/lib.rs
@@ -619,7 +619,7 @@ unsafe fn dwarf_unwind_one_frame(state: &mut DwarfUnwindState, proc_info: &ProcI
 
     // Find the mapping that contains current_ip
     let mut found_mapping = false;
-    let mut shard_id: u8 = SHARD_NONE;
+    let mut shard_id: u16 = SHARD_NONE;
     let mut table_count: u32 = 0;
     let mut load_bias: u64 = 0;
 
@@ -780,7 +780,7 @@ unsafe fn dwarf_copy_stack_regs(
 
         // Find the mapping that contains current_ip
         let mut found_mapping = false;
-        let mut shard_id: u8 = SHARD_NONE;
+        let mut shard_id: u16 = SHARD_NONE;
         let mut table_count: u32 = 0;
         let mut load_bias: u64 = 0;
 
@@ -1091,14 +1091,14 @@ unsafe fn try_fp_step(bp: u64) -> Option<(u64, u64)> {
 /// This avoids verifier state explosion that occurs when the two lookups
 /// are separated by typed wrapper code (MapDef::as_ptr() on the inner map).
 #[inline(always)]
-unsafe fn shard_lookup(shard_id: u8, idx: u32) -> Option<UnwindEntry> {
+unsafe fn shard_lookup(shard_id: u16, idx: u32) -> Option<UnwindEntry> {
     let entry: &UnwindEntry = UNWIND_SHARDS.get_value(shard_id as u32, &idx)?;
     Some(*entry)
 }
 
 #[inline(always)]
 unsafe fn binary_search_unwind_entry(
-    shard_id: u8,
+    shard_id: u16,
     table_count: u32,
     relative_pc: u32,
 ) -> Option<UnwindEntry> {

--- a/profile-bee/bin/profile-bee.rs
+++ b/profile-bee/bin/profile-bee.rs
@@ -38,7 +38,7 @@ enum PerfWork {
 /// Incremental DWARF unwind table update
 /// Each shard update is a (shard_id, entries) pair for a newly-loaded binary.
 struct DwarfRefreshUpdate {
-    shard_updates: Vec<(u8, Arc<Vec<UnwindEntry>>)>, // (shard_id, entries) for new shards
+    shard_updates: Vec<(u16, Arc<Vec<UnwindEntry>>)>, // (shard_id, entries) for new shards
     proc_info: Vec<(u32, ProcInfo)>,
 }
 
@@ -1137,7 +1137,7 @@ fn dwarf_refresh_loop(
 fn send_refresh(
     manager: &DwarfUnwindManager,
     tx: &mpsc::Sender<PerfWork>,
-    new_shard_ids: Vec<u8>,
+    new_shard_ids: Vec<u16>,
 ) -> Result<(), ()> {
     // Only clone the new shards (not the entire binary_tables)
     let mut shard_updates = Vec::new();

--- a/profile-bee/src/dwarf_unwind.rs
+++ b/profile-bee/src/dwarf_unwind.rs
@@ -392,14 +392,14 @@ pub struct DwarfUnwindManager {
     /// Per-process mapping information
     pub proc_info: HashMap<u32, ProcInfo>,
     /// Next shard_id to assign to a new binary
-    next_shard_id: u8,
+    next_shard_id: u16,
     /// Fast metadata-based cache for hot path lookups (stat-based)
-    metadata_cache: HashMap<FileMetadata, u8>, // metadata -> shard_id
+    metadata_cache: HashMap<FileMetadata, u16>, // metadata -> shard_id
     /// Cache of parsed ELF binary shard IDs, keyed by build ID
     /// Falls back to path-based caching for binaries without build IDs
-    binary_cache: HashMap<BuildId, u8>, // build_id -> shard_id
+    binary_cache: HashMap<BuildId, u16>, // build_id -> shard_id
     /// Fallback cache for binaries without build IDs (keyed by path)
-    path_cache: HashMap<std::path::PathBuf, u8>, // path -> shard_id
+    path_cache: HashMap<std::path::PathBuf, u16>, // path -> shard_id
 }
 
 impl Default for DwarfUnwindManager {
@@ -445,12 +445,12 @@ impl DwarfUnwindManager {
 
     /// Rescan a process's memory mappings and load any new ones.
     /// Returns the list of new shard IDs added (for incremental eBPF updates).
-    pub fn refresh_process(&mut self, tgid: u32) -> Result<Vec<u8>, String> {
+    pub fn refresh_process(&mut self, tgid: u32) -> Result<Vec<u16>, String> {
         // Track number of shards before update
         let old_len = self.binary_tables.len();
         self.scan_and_update(tgid)?;
         // Find new shards: those added after old_len
-        let new_shard_ids: Vec<u8> = (old_len as u8..self.binary_tables.len() as u8).collect();
+        let new_shard_ids: Vec<u16> = (old_len as u16..self.binary_tables.len() as u16).collect();
         Ok(new_shard_ids)
     }
 
@@ -498,7 +498,7 @@ impl DwarfUnwindManager {
                 end: 0,
                 load_bias: 0,
                 shard_id: SHARD_NONE,
-                _pad1: [0; 3],
+                _pad1: [0; 2],
                 table_count: 0,
             }; MAX_PROC_MAPS],
         });
@@ -714,7 +714,7 @@ impl DwarfUnwindManager {
                 end: end_addr,
                 load_bias,
                 shard_id,
-                _pad1: [0; 3],
+                _pad1: [0; 2],
                 table_count,
             };
             proc_info.mapping_count += 1;

--- a/profile-bee/src/ebpf.rs
+++ b/profile-bee/src/ebpf.rs
@@ -497,13 +497,13 @@ impl EbpfProfiler {
         manager: &crate::dwarf_unwind::DwarfUnwindManager,
     ) -> Result<(), anyhow::Error> {
         // Load all shards - using array indexing pattern
-        let all_shard_ids: Vec<u8> = (0..manager.binary_tables.len() as u8).collect();
+        let all_shard_ids: Vec<u16> = (0..manager.binary_tables.len() as u16).collect();
         self.update_dwarf_tables(manager, &all_shard_ids)
     }
 
     /// Load a single shard's unwind entries by creating a new inner Array map
     /// and inserting it into the outer ArrayOfMaps at `shard_id`.
-    fn load_shard(&mut self, shard_id: u8, entries: &[UnwindEntry]) -> Result<(), anyhow::Error> {
+    fn load_shard(&mut self, shard_id: u16, entries: &[UnwindEntry]) -> Result<(), anyhow::Error> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -540,7 +540,7 @@ impl EbpfProfiler {
     pub fn update_dwarf_tables(
         &mut self,
         manager: &crate::dwarf_unwind::DwarfUnwindManager,
-        new_shard_ids: &[u8],
+        new_shard_ids: &[u16],
     ) -> Result<(), anyhow::Error> {
         if !new_shard_ids.is_empty() {
             let mut total_entries = 0usize;
@@ -695,7 +695,7 @@ fn batch_populate_inner_map(
 /// referenced from the outer ArrayOfMaps; once inserted there, the returned
 /// Array handle (and its FD) can be dropped (the kernel holds its own reference).
 pub fn create_and_populate_inner_map(
-    shard_id: u8,
+    shard_id: u16,
     entries: &[UnwindEntry],
 ) -> Result<aya::maps::Array<MapData, UnwindEntryPod>, anyhow::Error> {
     if entries.is_empty() {


### PR DESCRIPTION
avoid running out of shards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DWARF unwinding limitations to reflect increased capacity for debug information processing.

* **Enhancements**
  * Expanded maximum capacity for handling binaries with DWARF debug tables from 8 to 512, enabling support for significantly more profiled applications with debug symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->