### PR TITLE
feat: add JITDump support for Bun/JSC JIT symbol resolution

### DIFF
--- a/profile-bee/bin/profile-bee.rs
+++ b/profile-bee/bin/profile-bee.rs
@@ -612,6 +612,7 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 
@@ -901,6 +902,35 @@ fn warn_nodejs_without_perf_map(pid: u32) {
     eprintln!("To enable JIT symbol resolution, restart Node.js with:");
     eprintln!("  node --perf-basic-prof --interpreted-frames-native-stack <script>");
     eprintln!("Or use profile-bee's auto-injection: probee -- node <script>\n");
+}
+
+/// Warn if profiling an already-running Bun process that lacks a JITDump
+/// file. Without `BUN_JSC_useJITDump=1`, JavaScriptCore JIT-compiled
+/// JavaScript functions show as `[unknown]` in flamegraphs.
+fn warn_bun_without_jitdump(pid: u32) {
+    let exe_link = format!("/proc/{}/exe", pid);
+    let exe_path = match std::fs::read_link(&exe_link) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let basename = exe_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if !profile_bee::spawn::is_bun_program(basename) {
+        return;
+    }
+
+    // Check for JITDump file
+    if profile_bee::jitdump::find_jitdump_for_pid(pid).is_some() {
+        return; // JITDump file present, JIT symbols will be resolved
+    }
+
+    eprintln!(
+        "\n\x1b[33mWarning: Profiling Bun process (PID {}) without JIT symbol support.\x1b[0m",
+        pid
+    );
+    eprintln!("JavaScript function names will appear as [unknown] in the flamegraph.");
+    eprintln!("To enable JIT symbol resolution, restart Bun with:");
+    eprintln!("  BUN_JSC_useJITDump=1 bun <script>");
+    eprintln!("Or use profile-bee's auto-injection: probee -- bun <script>\n");
 }
 
 /// Handle `probee symbolize <file.raw> [-o output.svg] [-o output.folded]`.
@@ -1631,10 +1661,11 @@ async fn run_combined_mode(
     let (mut ebpf_profiler, ring_buf, tgid_request_tx) =
         setup_ebpf_and_dwarf(&mut config, &perf_tx, pid, opt.dwarf.unwrap_or(false))?;
 
-    // Warn if targeting an existing Node.js process without perf-map
+    // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 
@@ -1739,10 +1770,11 @@ async fn run_tui_mode(opt: Opt) -> std::result::Result<(), anyhow::Error> {
     let (mut ebpf_profiler, ring_buf, tgid_request_tx) =
         setup_ebpf_and_dwarf(&mut config, &perf_tx, pid, opt.dwarf.unwrap_or(false))?;
 
-    // Warn if targeting an existing Node.js process without perf-map
+    // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 

--- a/profile-bee/bin/profile-bee.rs
+++ b/profile-bee/bin/profile-bee.rs
@@ -658,14 +658,13 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
         println!("Profiling PID {}..", target_pid);
     }
 
-    // Warn if profiling an existing Node.js process without perf-map file.
-    // When we spawn the process ourselves (--cmd / -- <command>), NODE_OPTIONS
-    // is injected automatically by setup_process_to_profile(). This warning
+    // Warn if profiling an existing Node.js/Bun process without JIT symbol support.
+    // When we spawn the process ourselves (--cmd / -- <command>), env vars are
+    // injected automatically by setup_process_to_profile(). This warning
     // only applies to --pid targeting an already-running process.
     if spawn.is_none() {
         if let Some(target_pid) = pid {
-            warn_nodejs_without_perf_map(target_pid);
-            warn_bun_without_jitdump(target_pid);
+            warn_unsupported_jit_runtimes(target_pid);
         }
     }
 
@@ -1151,6 +1150,14 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
     }
 
     Ok(())
+}
+
+/// Warn if profiling an already-running JIT runtime process that lacks
+/// the necessary symbol support files. Centralizes checks for all supported
+/// JIT runtimes (Node.js, Bun) into a single call.
+fn warn_unsupported_jit_runtimes(pid: u32) {
+    warn_nodejs_without_perf_map(pid);
+    warn_bun_without_jitdump(pid);
 }
 
 /// Warn if profiling an already-running Node.js process that lacks a perf-map
@@ -1954,8 +1961,7 @@ async fn run_combined_mode(
     // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
-            warn_nodejs_without_perf_map(target_pid);
-            warn_bun_without_jitdump(target_pid);
+            warn_unsupported_jit_runtimes(target_pid);
         }
     }
 
@@ -2089,8 +2095,7 @@ async fn run_tui_mode(opt: Opt) -> std::result::Result<(), anyhow::Error> {
     // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
-            warn_nodejs_without_perf_map(target_pid);
-            warn_bun_without_jitdump(target_pid);
+            warn_unsupported_jit_runtimes(target_pid);
         }
     }
 

--- a/profile-bee/bin/profile-bee.rs
+++ b/profile-bee/bin/profile-bee.rs
@@ -665,6 +665,7 @@ async fn main() -> std::result::Result<(), anyhow::Error> {
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 
@@ -1182,6 +1183,35 @@ fn warn_nodejs_without_perf_map(pid: u32) {
     eprintln!("To enable JIT symbol resolution, restart Node.js with:");
     eprintln!("  node --perf-basic-prof --interpreted-frames-native-stack <script>");
     eprintln!("Or use profile-bee's auto-injection: probee -- node <script>\n");
+}
+
+/// Warn if profiling an already-running Bun process that lacks a JITDump
+/// file. Without `BUN_JSC_useJITDump=1`, JavaScriptCore JIT-compiled
+/// JavaScript functions show as `[unknown]` in flamegraphs.
+fn warn_bun_without_jitdump(pid: u32) {
+    let exe_link = format!("/proc/{}/exe", pid);
+    let exe_path = match std::fs::read_link(&exe_link) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let basename = exe_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if !profile_bee::spawn::is_bun_program(basename) {
+        return;
+    }
+
+    // Check for JITDump file
+    if profile_bee::jitdump::find_jitdump_for_pid(pid).is_some() {
+        return; // JITDump file present, JIT symbols will be resolved
+    }
+
+    eprintln!(
+        "\n\x1b[33mWarning: Profiling Bun process (PID {}) without JIT symbol support.\x1b[0m",
+        pid
+    );
+    eprintln!("JavaScript function names will appear as [unknown] in the flamegraph.");
+    eprintln!("To enable JIT symbol resolution, restart Bun with:");
+    eprintln!("  BUN_JSC_useJITDump=1 bun <script>");
+    eprintln!("Or use profile-bee's auto-injection: probee -- bun <script>\n");
 }
 
 /// Handle `probee symbolize <file.raw> [-o output.svg] [-o output.folded]`.
@@ -1921,10 +1951,11 @@ async fn run_combined_mode(
     let (mut ebpf_profiler, ring_buf, tgid_request_tx) =
         setup_ebpf_and_dwarf(&mut config, &perf_tx, pid, opt.dwarf.unwrap_or(false))?;
 
-    // Warn if targeting an existing Node.js process without perf-map
+    // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 
@@ -2055,10 +2086,11 @@ async fn run_tui_mode(opt: Opt) -> std::result::Result<(), anyhow::Error> {
     let (mut ebpf_profiler, ring_buf, tgid_request_tx) =
         setup_ebpf_and_dwarf(&mut config, &perf_tx, pid, opt.dwarf.unwrap_or(false))?;
 
-    // Warn if targeting an existing Node.js process without perf-map
+    // Warn if targeting an existing Node.js/Bun process without JIT symbol support
     if spawn.is_none() {
         if let Some(target_pid) = pid {
             warn_nodejs_without_perf_map(target_pid);
+            warn_bun_without_jitdump(target_pid);
         }
     }
 

--- a/profile-bee/src/dwarf_unwind.rs
+++ b/profile-bee/src/dwarf_unwind.rs
@@ -56,6 +56,62 @@ pub enum DwarfUnwindError {
     VdsoInvalidRange,
 }
 
+/// Detect if an ELF binary is a Zig-compiled executable and return the
+/// virtual address of its `_start` function.
+///
+/// Zig is detected by the presence of any symbol with a `__zig` prefix.
+/// The `_start` address is needed to apply a stop-unwinding override that
+/// fixes bogus `.eh_frame` data emitted by older Zig compilers.
+///
+/// Returns `Some(start_vaddr)` if both a `__zig*` symbol and `_start` are found,
+/// `None` otherwise.
+///
+/// Reference: LightSwitch applies the same fix (see `lightswitch-object/src/object.rs`).
+fn detect_zig_start_address(obj: &object::File) -> Option<u64> {
+    use object::ObjectSymbol;
+
+    let mut is_zig = false;
+    let mut start_addr = None;
+
+    for symbol in obj.symbols() {
+        let Ok(name) = symbol.name() else { continue };
+        if name.starts_with("__zig") {
+            is_zig = true;
+        }
+        if name == "_start" && symbol.size() > 0 {
+            start_addr = Some(symbol.address());
+        }
+        // Early exit once both conditions are met
+        if is_zig && start_addr.is_some() {
+            break;
+        }
+    }
+
+    // Also check dynamic symbols if static symbols didn't have what we need
+    if !is_zig || start_addr.is_none() {
+        for symbol in obj.dynamic_symbols() {
+            let Ok(name) = symbol.name() else { continue };
+            if !is_zig && name.starts_with("__zig") {
+                is_zig = true;
+            }
+            if start_addr.is_none() && name == "_start" && symbol.size() > 0 {
+                start_addr = Some(symbol.address());
+            }
+            if is_zig && start_addr.is_some() {
+                break;
+            }
+        }
+    }
+
+    if is_zig {
+        if let Some(addr) = start_addr {
+            tracing::debug!("detected Zig binary with _start at {:#x}", addr);
+            return Some(addr);
+        }
+    }
+    None
+}
+
 /// Holds binary data either as a memory-mapped file or a heap-allocated buffer (for vdso).
 /// Using mmap avoids copying the entire ELF binary into userspace heap memory,
 /// eliminating page fault storms from anonymous page allocation + zeroing.
@@ -335,6 +391,12 @@ pub fn generate_unwind_table_from_bytes(
     // Extract build ID first
     let build_id = extract_build_id(data);
 
+    // Detect Zig binaries and find _start address for the unwind override.
+    // Older Zig compilers emit bogus .eh_frame data for _start, causing the
+    // unwinder to produce garbage frames at the stack bottom. We replace
+    // _start's unwind entry with a stop marker.
+    let zig_start_override = detect_zig_start_address(&obj);
+
     // Find the base virtual address (first PT_LOAD segment with file offset 0)
     // For non-PIE executables this is typically 0x400000, for PIE/shared libs it's 0.
     // We subtract this from .eh_frame PCs to make entries file-relative.
@@ -466,6 +528,28 @@ pub fn generate_unwind_table_from_bytes(
 
     // Sort by PC address for binary search
     entries.sort_by_key(|e| e.pc);
+
+    // Apply Zig _start override: replace unwind entries within _start's range
+    // with a stop marker. This causes the eBPF unwinder to terminate cleanly
+    // at the stack bottom instead of following bogus CFA rules.
+    if let Some(start_pc) = zig_start_override {
+        let start_pc_relative = (start_pc - base_vaddr) as u32;
+        for entry in entries.iter_mut() {
+            if entry.pc == start_pc_relative {
+                // CFA_REG_EXPRESSION is never emitted for valid entries (filtered above).
+                // The eBPF unwinder treats it as an unknown type → `return false` (stop).
+                entry.cfa_type = CFA_REG_EXPRESSION;
+                entry.cfa_offset = 0;
+                entry.rbp_type = REG_RULE_UNDEFINED;
+                entry.rbp_offset = 0;
+                tracing::debug!(
+                    "applied Zig _start stop-unwind override at relative PC {:#x}",
+                    start_pc_relative
+                );
+                break;
+            }
+        }
+    }
 
     // Deduplicate consecutive entries with identical unwind rules.
     // The binary search finds the last entry with pc <= target, so keeping
@@ -936,6 +1020,49 @@ mod tests {
     fn test_generate_unwind_table_invalid_elf() {
         let result = generate_unwind_table_from_bytes(b"not an elf file");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_zig_start_address_not_zig() {
+        // The test binary (Rust) should NOT be detected as Zig
+        let exe = std::env::current_exe().unwrap();
+        let data = std::fs::read(&exe).unwrap();
+        let obj = object::File::parse(&*data).unwrap();
+        let result = detect_zig_start_address(&obj);
+        assert!(
+            result.is_none(),
+            "Rust test binary should not be detected as Zig"
+        );
+    }
+
+    #[test]
+    fn test_detect_zig_start_address_bun() {
+        // Bun is a Zig-compiled binary — if installed, verify detection
+        let candidates = [
+            std::path::PathBuf::from("/usr/local/bin/bun"),
+            std::env::var("HOME")
+                .map(|h| std::path::PathBuf::from(h).join(".bun/bin/bun"))
+                .unwrap_or_default(),
+        ];
+        let path = match candidates.iter().find(|p| p.exists()) {
+            Some(p) => p.clone(),
+            None => return, // Bun not installed, skip
+        };
+        let data = match std::fs::read(&path) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        let obj = match object::File::parse(&*data) {
+            Ok(o) => o,
+            Err(_) => return,
+        };
+        let result = detect_zig_start_address(&obj);
+        // Bun is compiled with Zig so it should have __zig* symbols
+        // and _start. However, Bun is stripped so _start may not have size > 0.
+        // We just verify the function doesn't crash on a real Zig binary.
+        if result.is_some() {
+            assert!(result.unwrap() > 0);
+        }
     }
 
     #[test]

--- a/profile-bee/src/event_loop.rs
+++ b/profile-bee/src/event_loop.rs
@@ -13,6 +13,7 @@ use aya::Ebpf;
 use profile_bee_common::{StackInfo, EVENT_TRACE_ALWAYS, PROCESS_EVENT_EXEC, PROCESS_EVENT_EXIT};
 
 use crate::ebpf::{apply_dwarf_refresh, FramePointersPod, StackInfoPod, V8ProcInfoPod};
+use crate::jitdump::{self, JitSymbolTable};
 use crate::pipeline::{DwarfThreadMsg, PerfWork};
 use crate::process_metadata::ProcessMetadataCache;
 use crate::trace_handler::TraceHandler;
@@ -311,6 +312,61 @@ impl ProfilingEventLoop {
         }
     }
 
+    /// Try to load a JITDump symbol table for a newly-seen PID.
+    ///
+    /// Checks for `/tmp/jit-<pid>.dump` and, if found, parses it and
+    /// registers the symbol table in the trace handler. This enables
+    /// resolution of JIT-compiled function names from runtimes like
+    /// Bun (JavaScriptCore), Java HotSpot, and LuaJIT.
+    fn try_load_jitdump_for_pid(&mut self, tgid: u32) {
+        if self.trace_handler.has_jit_table(tgid) {
+            return;
+        }
+        if let Some(path) = jitdump::find_jitdump_for_pid(tgid) {
+            match JitSymbolTable::load_from_file(&path) {
+                Ok(table) if !table.is_empty() => {
+                    self.trace_handler.register_jit_table(tgid, table);
+                }
+                Ok(_) => tracing::debug!("JITDump for pid {} is empty", tgid),
+                Err(e) => tracing::debug!("JITDump read failed for pid {}: {}", tgid, e),
+            }
+        }
+    }
+
+    /// Reload JITDump symbol tables for all known PIDs.
+    ///
+    /// Used by streaming modes (TUI/serve) to pick up newly JIT-compiled
+    /// functions. For PIDs without an existing table, tries a fresh load.
+    /// For PIDs with a table, does an incremental reload from where the
+    /// last read left off.
+    pub fn reload_jitdump_tables(&mut self) {
+        for &tgid in &self.known_tgids.clone() {
+            if self.trace_handler.has_jit_table(tgid) {
+                // Incremental reload
+                if let Some(path) = jitdump::find_jitdump_for_pid(tgid) {
+                    if let Some(table) = self.trace_handler.jit_table_mut(tgid) {
+                        match table.reload_from_file(&path) {
+                            Ok(n) if n > 0 => {
+                                tracing::debug!(
+                                    "reloaded {} new JITDump symbols for pid {}",
+                                    n,
+                                    tgid
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                tracing::debug!("JITDump reload failed for pid {}: {}", tgid, e)
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Try fresh load
+                self.try_load_jitdump_for_pid(tgid);
+            }
+        }
+    }
+
     /// Drain events from the PerfWork channel, optionally symbolize stacks
     /// on the fly, and return `(local_counting, stopped)`.
     ///
@@ -383,10 +439,14 @@ impl ProfilingEventLoop {
                             // V8 introspection (eBPF FP context extraction +
                             // userspace heap reader for JS symbol resolution).
                             self.try_setup_v8_for_pid(stack.tgid);
+                            // Try loading JITDump symbols for runtimes like
+                            // Bun (JSC), Java HotSpot, and LuaJIT.
+                            self.try_load_jitdump_for_pid(stack.tgid);
                         }
                     } else if stack.tgid != 0 && self.known_tgids.insert(stack.tgid) {
                         // Even without DWARF thread, detect V8 processes
                         self.try_setup_v8_for_pid(stack.tgid);
+                        self.try_load_jitdump_for_pid(stack.tgid);
                     }
                     if local_counting {
                         let trace = self.trace_count.entry(stack).or_insert(0);
@@ -481,6 +541,14 @@ impl ProfilingEventLoop {
         }
 
         tracing::debug!("drain_events: processed {} events", queue_processed);
+
+        // Reload JITDump symbol tables at the end of the collection window.
+        // JIT runtimes (Bun, Java, etc.) write symbols incrementally as code
+        // is compiled — the initial load on first PID sight may have found an
+        // empty or nonexistent file. This final pass picks up all symbols
+        // written during the profiling window.
+        self.reload_jitdump_tables();
+
         (local_counting, stopped)
     }
 

--- a/profile-bee/src/event_loop.rs
+++ b/profile-bee/src/event_loop.rs
@@ -96,6 +96,9 @@ pub struct ProfilingEventLoop {
     // Persistent state across calls
     trace_count: HashMap<StackInfo, usize>,
     known_tgids: HashSet<u32>,
+    /// PIDs that have already been warned about missing JITDump files.
+    /// Prevents repeated warnings for the same Bun process.
+    warned_jitdump_pids: HashSet<u32>,
     /// Optional process metadata cache, maintained via eBPF lifecycle events.
     process_metadata: Option<ProcessMetadataCache>,
     /// PIDs that exited during the current drain_events() call.
@@ -130,6 +133,7 @@ impl ProfilingEventLoop {
             monitor_exit_pid: config.monitor_exit_pid,
             trace_count: HashMap::new(),
             known_tgids: HashSet::new(),
+            warned_jitdump_pids: HashSet::new(),
             process_metadata: if config.enable_process_metadata {
                 Some(ProcessMetadataCache::new(4096))
             } else {
@@ -318,6 +322,9 @@ impl ProfilingEventLoop {
     /// registers the symbol table in the trace handler. This enables
     /// resolution of JIT-compiled function names from runtimes like
     /// Bun (JavaScriptCore), Java HotSpot, and LuaJIT.
+    ///
+    /// If the PID is a Bun process and no JITDump file exists, emits a
+    /// warning so the user knows to restart Bun with `BUN_JSC_useJITDump=1`.
     fn try_load_jitdump_for_pid(&mut self, tgid: u32) {
         if self.trace_handler.has_jit_table(tgid) {
             return;
@@ -330,7 +337,48 @@ impl ProfilingEventLoop {
                 Ok(_) => tracing::debug!("JITDump for pid {} is empty", tgid),
                 Err(e) => tracing::debug!("JITDump read failed for pid {}: {}", tgid, e),
             }
+        } else {
+            // No JITDump file — check if this is a Bun process and warn
+            self.warn_bun_missing_jitdump(tgid);
         }
+    }
+
+    /// Emit a one-time warning if a PID is a Bun process without JITDump.
+    ///
+    /// Bun (JavaScriptCore) only writes JITDump files when started with
+    /// `BUN_JSC_useJITDump=1`. Without this, JIT-compiled JS functions
+    /// appear as `[unknown]`. This warning fires during system-wide and
+    /// `--pid` profiling where probee can't inject the env var itself.
+    fn warn_bun_missing_jitdump(&mut self, tgid: u32) {
+        if self.warned_jitdump_pids.contains(&tgid) {
+            return;
+        }
+        let exe_link = format!("/proc/{}/exe", tgid);
+        let exe_path = match std::fs::read_link(&exe_link) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let basename = exe_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if !crate::spawn::is_bun_program(basename) {
+            return;
+        }
+        self.warned_jitdump_pids.insert(tgid);
+        tracing::warn!(
+            "Bun process (PID {}) detected without JITDump file. \
+             JS function names will show as [unknown]. \
+             Restart Bun with: BUN_JSC_useJITDump=1 bun <script>",
+            tgid
+        );
+        eprintln!(
+            "\x1b[33mWarning: Bun process (PID {}) has no JITDump file.\x1b[0m",
+            tgid
+        );
+        eprintln!("  JS function names will appear as [unknown] in the flamegraph.");
+        eprintln!("  Restart Bun with: BUN_JSC_useJITDump=1 bun <script>");
+        eprintln!("  Or use probee's auto-injection: probee -- bun <script>");
     }
 
     /// Reload JITDump symbol tables for all known PIDs.

--- a/profile-bee/src/event_loop.rs
+++ b/profile-bee/src/event_loop.rs
@@ -339,8 +339,12 @@ impl ProfilingEventLoop {
     /// functions. For PIDs without an existing table, tries a fresh load.
     /// For PIDs with a table, does an incremental reload from where the
     /// last read left off.
+    ///
+    /// When new symbols are loaded, the symbol cache for that PID is
+    /// invalidated so previously-cached `[unknown]` frames get re-resolved.
     pub fn reload_jitdump_tables(&mut self) {
-        for &tgid in &self.known_tgids.clone() {
+        let tgids: Vec<u32> = self.known_tgids.iter().copied().collect();
+        for tgid in tgids {
             if self.trace_handler.has_jit_table(tgid) {
                 // Incremental reload
                 if let Some(path) = jitdump::find_jitdump_for_pid(tgid) {
@@ -352,6 +356,11 @@ impl ProfilingEventLoop {
                                     n,
                                     tgid
                                 );
+                                // Invalidate cached stacks for this PID so
+                                // previously-[unknown] frames get re-resolved
+                                // with the newly loaded JIT symbols. Use the
+                                // targeted invalidation that keeps the JIT table.
+                                self.trace_handler.invalidate_symbol_cache_for_pid(tgid);
                             }
                             Ok(_) => {}
                             Err(e) => {
@@ -547,7 +556,10 @@ impl ProfilingEventLoop {
         // is compiled — the initial load on first PID sight may have found an
         // empty or nonexistent file. This final pass picks up all symbols
         // written during the profiling window.
-        self.reload_jitdump_tables();
+        // Skip when symbolize=false (raw-capture path) to avoid unnecessary I/O.
+        if symbolize {
+            self.reload_jitdump_tables();
+        }
 
         (local_counting, stopped)
     }

--- a/profile-bee/src/jitdump.rs
+++ b/profile-bee/src/jitdump.rs
@@ -1,0 +1,710 @@
+//! JITDump file parser for resolving JIT-compiled function names.
+//!
+//! JITDump is a standard binary format written by JIT runtimes to map
+//! dynamically-generated code addresses to function names. Supported by
+//! Bun (JavaScriptCore via `BUN_JSC_useJITDump=1`), Node.js (`--perf-prof`),
+//! Java HotSpot, LuaJIT, and others.
+//!
+//! Reference: `tools/perf/Documentation/jitdump-specification.txt` in the
+//! Linux kernel source.
+//!
+//! This module provides a zero-dependency parser (std only) with a
+//! `BTreeMap`-backed symbol table for O(log n) address range lookups.
+
+use std::collections::{BTreeMap, HashMap};
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+// JITDump magic numbers
+const JITDUMP_MAGIC_LE: u32 = 0x4A695444; // "JiTD" little-endian
+const JITDUMP_MAGIC_BE: u32 = 0x4454694A; // "JiTD" big-endian
+
+// Record type IDs
+const JIT_CODE_LOAD: u32 = 0;
+const JIT_CODE_MOVE: u32 = 1;
+const JIT_CODE_DEBUG_INFO: u32 = 2;
+const JIT_CODE_CLOSE: u32 = 3;
+// const JIT_CODE_UNWINDING_INFO: u32 = 4; // not needed
+
+// Header size in bytes (10 fields)
+const JITDUMP_HEADER_SIZE: u64 = 40;
+
+// Record header size: id(u32) + total_size(u32) + timestamp(u64)
+const RECORD_HEADER_SIZE: u64 = 16;
+
+/// A single JIT symbol region: code address range -> function name.
+#[derive(Debug, Clone)]
+pub struct JitSymbol {
+    pub code_addr: u64,
+    pub code_size: u64,
+    pub name: String,
+    /// Optional source file + line from JIT_CODE_DEBUG_INFO.
+    pub source: Option<(String, u32)>,
+}
+
+/// Parsed JITDump symbol table for a single process.
+///
+/// Uses a `BTreeMap` keyed by `code_addr` for O(log n) range-based lookup.
+/// Supports incremental reloading for streaming/TUI modes.
+pub struct JitSymbolTable {
+    symbols: BTreeMap<u64, JitSymbol>,
+    /// Debug info that arrives before its corresponding JIT_CODE_LOAD.
+    /// Keyed by `code_index` (matches JIT_CODE_LOAD's `code_index` field).
+    pending_debug: HashMap<u64, (String, u32)>,
+    /// File offset for incremental reload — next read starts here.
+    last_read_offset: u64,
+}
+
+impl JitSymbolTable {
+    /// Look up a symbol by instruction pointer address.
+    ///
+    /// Returns the function name if `addr` falls within a known JIT region
+    /// `[code_addr, code_addr + code_size)`.
+    pub fn resolve(&self, addr: u64) -> Option<&JitSymbol> {
+        // Find the last entry with code_addr <= addr
+        self.symbols
+            .range(..=addr)
+            .next_back()
+            .map(|(_, sym)| sym)
+            .filter(|sym| addr < sym.code_addr + sym.code_size)
+    }
+
+    /// Parse a JITDump file and populate the symbol table.
+    ///
+    /// Tolerates partial/truncated files — returns whatever was successfully
+    /// parsed. This is important because the JIT runtime may still be writing
+    /// the file while we read it.
+    pub fn load_from_file(path: &Path) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut reader = BufReader::new(file);
+
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: 0,
+        };
+
+        // Parse and validate header
+        let _header = match parse_header(&mut reader) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!("JITDump header parse failed: {}", e);
+                return Ok(table);
+            }
+        };
+
+        table.last_read_offset = JITDUMP_HEADER_SIZE;
+
+        // Read records
+        table.read_records(&mut reader)?;
+
+        Ok(table)
+    }
+
+    /// Resume reading from a partially-read file for streaming modes.
+    ///
+    /// Seeks to `last_read_offset` and reads any new records appended since
+    /// the last read. Returns the number of new symbols loaded.
+    pub fn reload_from_file(&mut self, path: &Path) -> io::Result<usize> {
+        let file = std::fs::File::open(path)?;
+        let mut reader = BufReader::new(file);
+
+        reader.seek(SeekFrom::Start(self.last_read_offset))?;
+
+        let before = self.symbols.len();
+        self.read_records(&mut reader)?;
+        Ok(self.symbols.len() - before)
+    }
+
+    /// Number of symbols in the table.
+    pub fn len(&self) -> usize {
+        self.symbols.len()
+    }
+
+    /// Whether the table is empty.
+    pub fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
+    }
+
+    /// Read records from the current reader position until EOF or JIT_CODE_CLOSE.
+    fn read_records<R: Read + Seek>(&mut self, reader: &mut R) -> io::Result<()> {
+        loop {
+            let record_start = reader.stream_position()?;
+
+            // Read record header (16 bytes)
+            let (record_id, total_size, _timestamp) = match read_record_header(reader) {
+                Ok(h) => h,
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    // Partial file — stop reading, keep what we have
+                    self.last_read_offset = record_start;
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!("JITDump record header read error: {}", e);
+                    self.last_read_offset = record_start;
+                    break;
+                }
+            };
+
+            if total_size < RECORD_HEADER_SIZE as u32 {
+                tracing::debug!(
+                    "JITDump record with invalid size {} at offset {}",
+                    total_size,
+                    record_start
+                );
+                self.last_read_offset = record_start;
+                break;
+            }
+
+            let payload_size = total_size as u64 - RECORD_HEADER_SIZE;
+
+            match record_id {
+                JIT_CODE_LOAD => match self.parse_code_load(reader, payload_size) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        self.last_read_offset = record_start;
+                        break;
+                    }
+                },
+                JIT_CODE_MOVE => match self.parse_code_move(reader, payload_size) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        self.last_read_offset = record_start;
+                        break;
+                    }
+                },
+                JIT_CODE_DEBUG_INFO => match self.parse_debug_info(reader, payload_size) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        self.last_read_offset = record_start;
+                        break;
+                    }
+                },
+                JIT_CODE_CLOSE => {
+                    self.last_read_offset = record_start + total_size as u64;
+                    break;
+                }
+                _ => {
+                    // Unknown record type — skip
+                    skip_bytes(reader, payload_size)?;
+                }
+            }
+
+            self.last_read_offset = record_start + total_size as u64;
+        }
+
+        Ok(())
+    }
+
+    /// Parse a JIT_CODE_LOAD record.
+    ///
+    /// Fixed fields after record header:
+    ///   pid(u32), tid(u32), vma(u64), code_addr(u64), code_size(u64), code_index(u64)
+    /// Followed by: null-terminated function name, then raw code bytes.
+    fn parse_code_load<R: Read>(&mut self, reader: &mut R, payload_size: u64) -> io::Result<()> {
+        // Fixed fields: 4 + 4 + 8 + 8 + 8 + 8 = 40 bytes
+        const FIXED_SIZE: u64 = 40;
+        if payload_size < FIXED_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "JIT_CODE_LOAD too small",
+            ));
+        }
+
+        let _pid = read_u32(reader)?;
+        let _tid = read_u32(reader)?;
+        let _vma = read_u64(reader)?;
+        let code_addr = read_u64(reader)?;
+        let code_size = read_u64(reader)?;
+        let code_index = read_u64(reader)?;
+
+        // Remaining bytes: null-terminated name + code bytes
+        let remaining = payload_size - FIXED_SIZE;
+        let mut name_and_code = vec![0u8; remaining as usize];
+        reader.read_exact(&mut name_and_code)?;
+
+        // Extract null-terminated name
+        let name_end = name_and_code
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(name_and_code.len());
+        let name = String::from_utf8_lossy(&name_and_code[..name_end]).to_string();
+
+        // Check for pending debug info
+        let source = self.pending_debug.remove(&code_index);
+
+        self.symbols.insert(
+            code_addr,
+            JitSymbol {
+                code_addr,
+                code_size,
+                name,
+                source,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Parse a JIT_CODE_MOVE record.
+    ///
+    /// Fixed fields: old_code_addr(u64), new_code_addr(u64),
+    ///               new_code_size(u64), code_index(u64)
+    fn parse_code_move<R: Read>(&mut self, reader: &mut R, payload_size: u64) -> io::Result<()> {
+        const FIXED_SIZE: u64 = 32;
+        if payload_size < FIXED_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "JIT_CODE_MOVE too small",
+            ));
+        }
+
+        let old_code_addr = read_u64(reader)?;
+        let new_code_addr = read_u64(reader)?;
+        let new_code_size = read_u64(reader)?;
+        let _code_index = read_u64(reader)?;
+
+        // Skip any remaining payload
+        if payload_size > FIXED_SIZE {
+            skip_bytes(reader, payload_size - FIXED_SIZE)?;
+        }
+
+        // Move the symbol entry
+        if let Some(mut sym) = self.symbols.remove(&old_code_addr) {
+            sym.code_addr = new_code_addr;
+            sym.code_size = new_code_size;
+            self.symbols.insert(new_code_addr, sym);
+        }
+
+        Ok(())
+    }
+
+    /// Parse a JIT_CODE_DEBUG_INFO record.
+    ///
+    /// Fixed fields: code_addr(u64), nr_entry(u64)
+    /// Followed by array of debug entries: addr(u64), line(u32), discrim(u32),
+    /// then null-terminated filename.
+    ///
+    /// Per spec, DEBUG_INFO must appear before its corresponding CODE_LOAD.
+    /// We store the first entry's (filename, line) in pending_debug keyed by
+    /// code_addr (used as a proxy for code_index).
+    fn parse_debug_info<R: Read>(&mut self, reader: &mut R, payload_size: u64) -> io::Result<()> {
+        if payload_size < 16 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "JIT_CODE_DEBUG_INFO too small",
+            ));
+        }
+
+        let code_addr = read_u64(reader)?;
+        let nr_entry = read_u64(reader)?;
+
+        // Read the first debug entry if available, skip the rest.
+        // Each entry: addr(u64) + line(u32) + discrim(u32) + null-terminated filename
+        let mut consumed = 16u64;
+        if nr_entry > 0 && payload_size > consumed + 16 {
+            let _entry_addr = read_u64(reader)?;
+            let line = read_u32(reader)?;
+            let _discrim = read_u32(reader)?;
+            consumed += 16;
+
+            // Read null-terminated filename from remaining payload
+            let remaining = payload_size - consumed;
+            let mut buf = vec![0u8; remaining as usize];
+            reader.read_exact(&mut buf)?;
+
+            let name_end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+            let filename = String::from_utf8_lossy(&buf[..name_end]).to_string();
+
+            if !filename.is_empty() {
+                self.pending_debug.insert(code_addr, (filename, line));
+            }
+
+            return Ok(());
+        }
+
+        // Skip remaining payload
+        if payload_size > consumed {
+            skip_bytes(reader, payload_size - consumed)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Check if a JITDump file exists for the given PID.
+///
+/// Searches for JITDump files in `/tmp/` using two naming conventions:
+/// 1. Standard: `/tmp/jit-<pid>.dump` (used by Java HotSpot, LuaJIT, `perf`)
+/// 2. JSC/Bun: `/tmp/jit-<tid>-<pid>-<random>` (used by JavaScriptCore)
+///
+/// Returns the first matching file path, preferring the standard convention.
+pub fn find_jitdump_for_pid(pid: u32) -> Option<PathBuf> {
+    // Standard convention: /tmp/jit-<pid>.dump
+    let standard = PathBuf::from(format!("/tmp/jit-{}.dump", pid));
+    if standard.exists() {
+        return Some(standard);
+    }
+
+    // JSC/Bun convention: /tmp/jit-<tid>-<pid>-<random>
+    // Scan /tmp/ for files matching this pattern.
+    let prefix = format!("jit-");
+    let pid_str = pid.to_string();
+    if let Ok(entries) = std::fs::read_dir("/tmp") {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            // Match pattern: jit-<digits>-<pid>-<alphanum>
+            if name.starts_with(&prefix) && name.contains(&format!("-{}-", pid_str)) {
+                return Some(entry.path());
+            }
+        }
+    }
+
+    None
+}
+
+/// Format a JIT symbol for display in flamegraphs.
+///
+/// If source file info is available: `functionName (file.js:42)`
+/// Otherwise just: `functionName`
+pub fn format_jit_symbol(sym: &JitSymbol) -> String {
+    if let Some((ref file, line)) = sym.source {
+        let basename = Path::new(file)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or(file);
+        format!("{} ({}:{})", sym.name, basename, line)
+    } else {
+        sym.name.clone()
+    }
+}
+
+// ── Binary reading helpers ──────────────────────────────────────────────────
+
+/// JITDump file header (40 bytes).
+struct JitdumpHeader {
+    _version: u32,
+    _elf_mach: u32,
+    _pid: u32,
+}
+
+fn parse_header<R: Read>(reader: &mut R) -> io::Result<JitdumpHeader> {
+    let magic = read_u32(reader)?;
+    if magic != JITDUMP_MAGIC_LE && magic != JITDUMP_MAGIC_BE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid JITDump magic: {:#x}", magic),
+        ));
+    }
+    if magic == JITDUMP_MAGIC_BE {
+        // We only support little-endian (x86_64). Big-endian JITDump files
+        // are theoretically possible but not encountered in practice.
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "big-endian JITDump not supported",
+        ));
+    }
+
+    let version = read_u32(reader)?;
+    let _total_size = read_u32(reader)?;
+    let elf_mach = read_u32(reader)?;
+    let _pad1 = read_u32(reader)?;
+    let pid = read_u32(reader)?;
+    let _timestamp = read_u64(reader)?;
+    let _flags = read_u64(reader)?;
+
+    Ok(JitdumpHeader {
+        _version: version,
+        _elf_mach: elf_mach,
+        _pid: pid,
+    })
+}
+
+fn read_record_header<R: Read>(reader: &mut R) -> io::Result<(u32, u32, u64)> {
+    let id = read_u32(reader)?;
+    let total_size = read_u32(reader)?;
+    let timestamp = read_u64(reader)?;
+    Ok((id, total_size, timestamp))
+}
+
+fn read_u32<R: Read>(reader: &mut R) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn read_u64<R: Read>(reader: &mut R) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn skip_bytes<R: Read>(reader: &mut R, n: u64) -> io::Result<()> {
+    // For BufReader, seeking is more efficient but Read doesn't guarantee Seek.
+    // Use a small buffer to discard bytes.
+    let mut remaining = n;
+    let mut buf = [0u8; 4096];
+    while remaining > 0 {
+        let to_read = remaining.min(buf.len() as u64) as usize;
+        reader.read_exact(&mut buf[..to_read])?;
+        remaining -= to_read as u64;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Build a minimal JITDump file in memory with the given records.
+    fn build_jitdump(records: &[Vec<u8>]) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Header (40 bytes)
+        buf.extend_from_slice(&JITDUMP_MAGIC_LE.to_le_bytes()); // magic
+        buf.extend_from_slice(&1u32.to_le_bytes()); // version
+        buf.extend_from_slice(&40u32.to_le_bytes()); // total_size (header)
+        buf.extend_from_slice(&0x3Eu32.to_le_bytes()); // elf_mach (EM_X86_64)
+        buf.extend_from_slice(&0u32.to_le_bytes()); // pad1
+        buf.extend_from_slice(&1234u32.to_le_bytes()); // pid
+        buf.extend_from_slice(&0u64.to_le_bytes()); // timestamp
+        buf.extend_from_slice(&0u64.to_le_bytes()); // flags
+
+        for record in records {
+            buf.extend_from_slice(record);
+        }
+
+        buf
+    }
+
+    /// Build a JIT_CODE_LOAD record.
+    fn code_load_record(code_addr: u64, code_size: u64, code_index: u64, name: &str) -> Vec<u8> {
+        let name_bytes = name.as_bytes();
+        // name + null terminator, no code bytes for simplicity
+        let payload_size = 40 + name_bytes.len() as u32 + 1;
+        let total_size = 16 + payload_size;
+
+        let mut rec = Vec::new();
+        rec.extend_from_slice(&JIT_CODE_LOAD.to_le_bytes()); // id
+        rec.extend_from_slice(&total_size.to_le_bytes()); // total_size
+        rec.extend_from_slice(&0u64.to_le_bytes()); // timestamp
+
+        // Fixed payload
+        rec.extend_from_slice(&1234u32.to_le_bytes()); // pid
+        rec.extend_from_slice(&1234u32.to_le_bytes()); // tid
+        rec.extend_from_slice(&code_addr.to_le_bytes()); // vma
+        rec.extend_from_slice(&code_addr.to_le_bytes()); // code_addr
+        rec.extend_from_slice(&code_size.to_le_bytes()); // code_size
+        rec.extend_from_slice(&code_index.to_le_bytes()); // code_index
+
+        // Name + null
+        rec.extend_from_slice(name_bytes);
+        rec.push(0);
+
+        rec
+    }
+
+    /// Build a JIT_CODE_MOVE record.
+    fn code_move_record(old_addr: u64, new_addr: u64, new_size: u64, code_index: u64) -> Vec<u8> {
+        let total_size: u32 = 16 + 32;
+        let mut rec = Vec::new();
+        rec.extend_from_slice(&JIT_CODE_MOVE.to_le_bytes());
+        rec.extend_from_slice(&total_size.to_le_bytes());
+        rec.extend_from_slice(&0u64.to_le_bytes()); // timestamp
+        rec.extend_from_slice(&old_addr.to_le_bytes());
+        rec.extend_from_slice(&new_addr.to_le_bytes());
+        rec.extend_from_slice(&new_size.to_le_bytes());
+        rec.extend_from_slice(&code_index.to_le_bytes());
+        rec
+    }
+
+    /// Build a JIT_CODE_CLOSE record.
+    fn close_record() -> Vec<u8> {
+        let mut rec = Vec::new();
+        rec.extend_from_slice(&JIT_CODE_CLOSE.to_le_bytes());
+        rec.extend_from_slice(&16u32.to_le_bytes()); // total_size = header only
+        rec.extend_from_slice(&0u64.to_le_bytes()); // timestamp
+        rec
+    }
+
+    #[test]
+    fn test_parse_single_symbol() {
+        let data = build_jitdump(&[code_load_record(0x1000, 0x100, 0, "myFunction")]);
+        let mut cursor = Cursor::new(data);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        assert_eq!(table.len(), 1);
+
+        // Exact start address
+        let sym = table.resolve(0x1000).unwrap();
+        assert_eq!(sym.name, "myFunction");
+        assert_eq!(sym.code_size, 0x100);
+
+        // Middle of the range
+        assert!(table.resolve(0x1050).is_some());
+
+        // Just before the end
+        assert!(table.resolve(0x10FF).is_some());
+
+        // At the end (exclusive)
+        assert!(table.resolve(0x1100).is_none());
+
+        // Before the start
+        assert!(table.resolve(0x0FFF).is_none());
+    }
+
+    #[test]
+    fn test_parse_multiple_symbols() {
+        let data = build_jitdump(&[
+            code_load_record(0x1000, 0x100, 0, "funcA"),
+            code_load_record(0x2000, 0x200, 1, "funcB"),
+            code_load_record(0x3000, 0x50, 2, "funcC"),
+        ]);
+        let mut cursor = Cursor::new(data);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        assert_eq!(table.len(), 3);
+        assert_eq!(table.resolve(0x1050).unwrap().name, "funcA");
+        assert_eq!(table.resolve(0x2100).unwrap().name, "funcB");
+        assert_eq!(table.resolve(0x3000).unwrap().name, "funcC");
+
+        // In the gap between funcA and funcB
+        assert!(table.resolve(0x1500).is_none());
+    }
+
+    #[test]
+    fn test_code_move() {
+        let data = build_jitdump(&[
+            code_load_record(0x1000, 0x100, 0, "movedFunc"),
+            code_move_record(0x1000, 0x5000, 0x200, 0),
+        ]);
+        let mut cursor = Cursor::new(data);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        assert_eq!(table.len(), 1);
+        // Old address should not resolve
+        assert!(table.resolve(0x1050).is_none());
+        // New address should resolve
+        let sym = table.resolve(0x5050).unwrap();
+        assert_eq!(sym.name, "movedFunc");
+        assert_eq!(sym.code_size, 0x200);
+    }
+
+    #[test]
+    fn test_close_record_stops_parsing() {
+        let data = build_jitdump(&[
+            code_load_record(0x1000, 0x100, 0, "beforeClose"),
+            close_record(),
+            code_load_record(0x2000, 0x100, 1, "afterClose"),
+        ]);
+        let mut cursor = Cursor::new(data);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        assert_eq!(table.len(), 1);
+        assert!(table.resolve(0x1050).is_some());
+        assert!(table.resolve(0x2050).is_none());
+    }
+
+    #[test]
+    fn test_truncated_file() {
+        // Build a valid file but truncate it mid-record
+        let data = build_jitdump(&[code_load_record(0x1000, 0x100, 0, "complete")]);
+        let mut truncated = data.clone();
+        // Append a partial second record (just the header, no payload)
+        truncated.extend_from_slice(&JIT_CODE_LOAD.to_le_bytes());
+        truncated.extend_from_slice(&100u32.to_le_bytes()); // total_size
+                                                            // No more bytes — truncated
+
+        let mut cursor = Cursor::new(truncated);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        // Should have the first complete symbol
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.resolve(0x1050).unwrap().name, "complete");
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let mut data = vec![0u8; 40];
+        data[0..4].copy_from_slice(&0xDEADBEEFu32.to_le_bytes());
+        let mut cursor = Cursor::new(data);
+        assert!(parse_header(&mut cursor).is_err());
+    }
+
+    #[test]
+    fn test_format_jit_symbol_with_source() {
+        let sym = JitSymbol {
+            code_addr: 0x1000,
+            code_size: 0x100,
+            name: "handleRequest".to_string(),
+            source: Some(("/home/user/app/server.js".to_string(), 42)),
+        };
+        assert_eq!(format_jit_symbol(&sym), "handleRequest (server.js:42)");
+    }
+
+    #[test]
+    fn test_format_jit_symbol_without_source() {
+        let sym = JitSymbol {
+            code_addr: 0x1000,
+            code_size: 0x100,
+            name: "anonymous".to_string(),
+            source: None,
+        };
+        assert_eq!(format_jit_symbol(&sym), "anonymous");
+    }
+
+    #[test]
+    fn test_find_jitdump_nonexistent() {
+        // PID 0 should never have a JITDump file
+        assert!(find_jitdump_for_pid(0).is_none());
+    }
+
+    #[test]
+    fn test_empty_table() {
+        let data = build_jitdump(&[]);
+        let mut cursor = Cursor::new(data);
+        let _header = parse_header(&mut cursor).unwrap();
+        let mut table = JitSymbolTable {
+            symbols: BTreeMap::new(),
+            pending_debug: HashMap::new(),
+            last_read_offset: JITDUMP_HEADER_SIZE,
+        };
+        table.read_records(&mut cursor).unwrap();
+
+        assert_eq!(table.len(), 0);
+        assert!(table.is_empty());
+        assert!(table.resolve(0x1000).is_none());
+    }
+}

--- a/profile-bee/src/jitdump.rs
+++ b/profile-bee/src/jitdump.rs
@@ -408,18 +408,38 @@ pub fn find_jitdump_for_pid_in_dir(pid: u32, dir: &Path) -> Option<PathBuf> {
 
 /// Format a JIT symbol for display in flamegraphs.
 ///
+/// Cleans up JSC-specific noise from the symbol name:
+/// - Strips `#<hash>` suffixes (JSC JIT code version hashes, e.g. `hello#DdCypB` → `hello`)
+///
 /// If source file info is available: `functionName (file.js:42)`
 /// Otherwise just: `functionName`
 pub fn format_jit_symbol(sym: &JitSymbol) -> String {
+    let name = strip_jsc_hash(&sym.name);
     if let Some((ref file, line)) = sym.source {
         let basename = Path::new(file)
             .file_name()
             .and_then(|f| f.to_str())
             .unwrap_or(file);
-        format!("{} ({}:{})", sym.name, basename, line)
+        format!("{} ({}:{})", name, basename, line)
     } else {
-        sym.name.clone()
+        name.to_string()
     }
+}
+
+/// Strip JSC JIT code version hash from a symbol name.
+///
+/// JSC appends `#<alphanumeric>` to JIT-compiled function names to
+/// disambiguate recompilations (e.g. `hello#DdCypB`, `/tmp/test.js#B9UAQK`).
+/// This is internal noise that obscures the actual function name.
+fn strip_jsc_hash(name: &str) -> &str {
+    if let Some(pos) = name.rfind('#') {
+        let suffix = &name[pos + 1..];
+        // Only strip if the suffix is non-empty alphanumeric (JSC hash format)
+        if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_alphanumeric()) {
+            return &name[..pos];
+        }
+    }
+    name
 }
 
 // ── Binary reading helpers ──────────────────────────────────────────────────
@@ -710,7 +730,7 @@ mod tests {
         let sym = JitSymbol {
             code_addr: 0x1000,
             code_size: 0x100,
-            name: "handleRequest".to_string(),
+            name: "handleRequest#AbCdEf".to_string(),
             source: Some(("/home/user/app/server.js".to_string(), 42)),
         };
         assert_eq!(format_jit_symbol(&sym), "handleRequest (server.js:42)");
@@ -721,10 +741,30 @@ mod tests {
         let sym = JitSymbol {
             code_addr: 0x1000,
             code_size: 0x100,
+            name: "hello#DdCypB".to_string(),
+            source: None,
+        };
+        assert_eq!(format_jit_symbol(&sym), "hello");
+    }
+
+    #[test]
+    fn test_format_jit_symbol_no_hash() {
+        let sym = JitSymbol {
+            code_addr: 0x1000,
+            code_size: 0x100,
             name: "anonymous".to_string(),
             source: None,
         };
         assert_eq!(format_jit_symbol(&sym), "anonymous");
+    }
+
+    #[test]
+    fn test_strip_jsc_hash() {
+        assert_eq!(strip_jsc_hash("hello#DdCypB"), "hello");
+        assert_eq!(strip_jsc_hash("/tmp/test.js#B9UAQK"), "/tmp/test.js");
+        assert_eq!(strip_jsc_hash("no_hash"), "no_hash");
+        // Don't strip if suffix contains non-alphanumeric
+        assert_eq!(strip_jsc_hash("color#ff-00"), "color#ff-00");
     }
 
     #[test]

--- a/profile-bee/src/jitdump.rs
+++ b/profile-bee/src/jitdump.rs
@@ -105,10 +105,37 @@ impl JitSymbolTable {
     ///
     /// Seeks to `last_read_offset` and reads any new records appended since
     /// the last read. Returns the number of new symbols loaded.
+    ///
+    /// If the file has been truncated or rotated (size < last_read_offset),
+    /// resets state and re-parses from the beginning.
     pub fn reload_from_file(&mut self, path: &Path) -> io::Result<usize> {
         let file = std::fs::File::open(path)?;
-        let mut reader = BufReader::new(file);
+        let file_len = file.metadata()?.len();
 
+        // Detect truncated/rotated file — reset and re-parse from scratch
+        if file_len < self.last_read_offset {
+            tracing::debug!(
+                "JITDump file shrunk ({} < {}), resetting",
+                file_len,
+                self.last_read_offset
+            );
+            self.symbols.clear();
+            self.pending_debug.clear();
+            self.last_read_offset = 0;
+
+            let mut reader = BufReader::new(file);
+            match parse_header(&mut reader) {
+                Ok(_) => {
+                    self.last_read_offset = JITDUMP_HEADER_SIZE;
+                    let before = self.symbols.len();
+                    self.read_records(&mut reader)?;
+                    return Ok(self.symbols.len() - before);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let mut reader = BufReader::new(file);
         reader.seek(SeekFrom::Start(self.last_read_offset))?;
 
         let before = self.symbols.len();
@@ -216,7 +243,7 @@ impl JitSymbolTable {
         let _vma = read_u64(reader)?;
         let code_addr = read_u64(reader)?;
         let code_size = read_u64(reader)?;
-        let code_index = read_u64(reader)?;
+        let _code_index = read_u64(reader)?;
 
         // Remaining bytes: null-terminated name + code bytes
         let remaining = payload_size - FIXED_SIZE;
@@ -230,8 +257,9 @@ impl JitSymbolTable {
             .unwrap_or(name_and_code.len());
         let name = String::from_utf8_lossy(&name_and_code[..name_end]).to_string();
 
-        // Check for pending debug info
-        let source = self.pending_debug.remove(&code_index);
+        // Check for pending debug info (keyed by code_addr — the same
+        // address that appeared in the preceding JIT_CODE_DEBUG_INFO record)
+        let source = self.pending_debug.remove(&code_addr);
 
         self.symbols.insert(
             code_addr,
@@ -287,7 +315,8 @@ impl JitSymbolTable {
     ///
     /// Per spec, DEBUG_INFO must appear before its corresponding CODE_LOAD.
     /// We store the first entry's (filename, line) in pending_debug keyed by
-    /// code_addr (used as a proxy for code_index).
+    /// `code_addr` — the same address that will appear in the subsequent
+    /// JIT_CODE_LOAD record's `code_addr` field.
     fn parse_debug_info<R: Read>(&mut self, reader: &mut R, payload_size: u64) -> io::Result<()> {
         if payload_size < 16 {
             return Err(io::Error::new(
@@ -340,22 +369,35 @@ impl JitSymbolTable {
 ///
 /// Returns the first matching file path, preferring the standard convention.
 pub fn find_jitdump_for_pid(pid: u32) -> Option<PathBuf> {
-    // Standard convention: /tmp/jit-<pid>.dump
-    let standard = PathBuf::from(format!("/tmp/jit-{}.dump", pid));
+    find_jitdump_for_pid_in_dir(pid, Path::new("/tmp"))
+}
+
+/// Search for a JITDump file for the given PID in the specified directory.
+///
+/// This is the testable core of [`find_jitdump_for_pid`], allowing tests to
+/// use an isolated directory instead of the global `/tmp`.
+pub fn find_jitdump_for_pid_in_dir(pid: u32, dir: &Path) -> Option<PathBuf> {
+    // Standard convention: jit-<pid>.dump
+    let standard = dir.join(format!("jit-{}.dump", pid));
     if standard.exists() {
         return Some(standard);
     }
 
-    // JSC/Bun convention: /tmp/jit-<tid>-<pid>-<random>
-    // Scan /tmp/ for files matching this pattern.
-    let prefix = format!("jit-");
+    // JSC/Bun convention: jit-<tid>-<pid>-<random>
+    // Scan directory for files matching this pattern.
     let pid_str = pid.to_string();
-    if let Ok(entries) = std::fs::read_dir("/tmp") {
+    if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
             // Match pattern: jit-<digits>-<pid>-<alphanum>
-            if name.starts_with(&prefix) && name.contains(&format!("-{}-", pid_str)) {
+            // Split on '-' and verify PID is in the expected segment (index 2).
+            if !name.starts_with("jit-") {
+                continue;
+            }
+            let parts: Vec<&str> = name.splitn(4, '-').collect();
+            // parts: ["jit", "<tid>", "<pid>", "<random>"]
+            if parts.len() >= 4 && parts[2] == pid_str {
                 return Some(entry.path());
             }
         }
@@ -687,8 +729,41 @@ mod tests {
 
     #[test]
     fn test_find_jitdump_nonexistent() {
-        // PID 0 should never have a JITDump file
-        assert!(find_jitdump_for_pid(0).is_none());
+        // Use an isolated temp directory so stale files in /tmp can't cause false failures
+        let dir = std::env::temp_dir().join("jitdump_test_nonexistent");
+        let _ = std::fs::create_dir_all(&dir);
+        // Clean any leftovers from previous test runs
+        for entry in std::fs::read_dir(&dir).into_iter().flatten().flatten() {
+            let _ = std::fs::remove_file(entry.path());
+        }
+        assert!(find_jitdump_for_pid_in_dir(99999, &dir).is_none());
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_find_jitdump_standard_convention() {
+        let dir = std::env::temp_dir().join("jitdump_test_standard");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("jit-1234.dump");
+        std::fs::write(&path, b"dummy").unwrap();
+        let found = find_jitdump_for_pid_in_dir(1234, &dir);
+        assert_eq!(found, Some(path.clone()));
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_find_jitdump_jsc_convention() {
+        let dir = std::env::temp_dir().join("jitdump_test_jsc");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("jit-5678-1234-AbCdEf");
+        std::fs::write(&path, b"dummy").unwrap();
+        let found = find_jitdump_for_pid_in_dir(1234, &dir);
+        assert_eq!(found, Some(path.clone()));
+        // Verify it doesn't match wrong PID
+        assert!(find_jitdump_for_pid_in_dir(5678, &dir).is_none());
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
     }
 
     #[test]

--- a/profile-bee/src/lib.rs
+++ b/profile-bee/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pprof;
 pub mod probe_resolver;
 pub mod probe_spec;
 
+pub mod jitdump;
 pub mod v8;
 
 mod trace_handler;

--- a/profile-bee/src/lib.rs
+++ b/profile-bee/src/lib.rs
@@ -33,6 +33,7 @@ pub mod embedded_symbol_server;
 pub mod probe_resolver;
 pub mod probe_spec;
 
+pub mod jitdump;
 pub mod v8;
 
 mod trace_handler;

--- a/profile-bee/src/spawn.rs
+++ b/profile-bee/src/spawn.rs
@@ -180,6 +180,15 @@ fn is_nodejs_program(program: &str) -> bool {
     matches!(basename, "node" | "nodejs" | "nsolid")
 }
 
+/// Check if a program name looks like Bun.
+pub fn is_bun_program(program: &str) -> bool {
+    let basename = Path::new(program)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(program);
+    matches!(basename, "bun" | "bunx")
+}
+
 /// Build extra environment variables for runtime-specific profiling support.
 ///
 /// For Node.js processes, injects `NODE_OPTIONS` with `--perf-prof` (writes
@@ -219,6 +228,14 @@ fn build_runtime_env(program: &str) -> Vec<(&'static str, String)> {
             value
         );
         env.push(("NODE_OPTIONS", value));
+    }
+
+    if is_bun_program(program) {
+        // BUN_JSC_useJITDump=1: writes /tmp/jit-<pid>.dump with JIT symbol
+        // addresses for JavaScriptCore. This lets us resolve JIT-compiled
+        // JavaScript function names that would otherwise appear as [unknown].
+        tracing::info!("Bun detected: injecting BUN_JSC_useJITDump=1 for JIT symbol resolution");
+        env.push(("BUN_JSC_useJITDump", "1".to_string()));
     }
 
     env

--- a/profile-bee/src/symbolize.rs
+++ b/profile-bee/src/symbolize.rs
@@ -22,6 +22,8 @@ use blazesym::symbolize::source::{Kernel, Process, Source};
 use blazesym::symbolize::{Input, Symbolized, Symbolizer};
 use blazesym::Pid;
 
+use crate::jitdump::{self, JitSymbolTable};
+
 /// A parsed raw stack sample (one line of the raw collapse file).
 #[derive(Debug)]
 struct RawLine {
@@ -60,6 +62,21 @@ pub fn symbolize_raw_file(path: &Path) -> anyhow::Result<Vec<String>> {
 
     // Determine PIDs from mappings header
     let pids: Vec<u32> = mappings.keys().copied().collect();
+
+    // Load JITDump symbol tables for any PIDs that have them
+    let mut jit_tables: HashMap<u32, JitSymbolTable> = HashMap::new();
+    for &pid in &pids {
+        if let Some(path) = jitdump::find_jitdump_for_pid(pid) {
+            match JitSymbolTable::load_from_file(&path) {
+                Ok(table) if !table.is_empty() => {
+                    tracing::info!("loaded JITDump for pid {} ({} symbols)", pid, table.len());
+                    jit_tables.insert(pid, table);
+                }
+                Ok(_) => {}
+                Err(e) => tracing::debug!("JITDump read failed for pid {}: {}", pid, e),
+            }
+        }
+    }
 
     let symbolizer = Symbolizer::new();
     let mut output = Vec::new();
@@ -104,10 +121,23 @@ pub fn symbolize_raw_file(path: &Path) -> anyhow::Result<Vec<String>> {
         if !sample.user_addrs.is_empty() {
             if let Some(pid) = target_pid {
                 let src = Source::Process(Process::new(Pid::from(pid)));
+                let jit_table = jit_tables.get(&pid);
                 match symbolizer.symbolize(&src, Input::AbsAddr(&sample.user_addrs)) {
                     Ok(syms) => {
-                        for sym in syms {
-                            frames.push(format_symbolized(sym, false));
+                        for (i, sym) in syms.into_iter().enumerate() {
+                            let formatted = format_symbolized(sym, false);
+                            // Override [unknown] with JITDump symbol if available
+                            if formatted == "[unknown]" {
+                                if let Some(table) = jit_table {
+                                    if let Some(addr) = sample.user_addrs.get(i) {
+                                        if let Some(jit_sym) = table.resolve(*addr) {
+                                            frames.push(jitdump::format_jit_symbol(jit_sym));
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            frames.push(formatted);
                         }
                     }
                     Err(e) => {

--- a/profile-bee/src/trace_handler.rs
+++ b/profile-bee/src/trace_handler.rs
@@ -1,4 +1,5 @@
 use crate::ebpf::{FramePointersPod, StackInfoPod};
+use crate::jitdump::{self, JitSymbolTable};
 use crate::v8::{V8HeapReader, V8IntrospectionData};
 use crate::{cache::PointerStackFramesCache, types::StackFrameInfo, types::StackInfoExt};
 use aya::maps::MapData;
@@ -203,6 +204,10 @@ pub struct TraceHandler {
     /// V8 heap readers per PID, for resolving JavaScript function names
     /// from SFI pointers extracted by the eBPF V8 frame extractor.
     v8_readers: HashMap<u32, V8HeapReader>,
+    /// JITDump symbol tables per PID, for resolving JIT-compiled function
+    /// names from runtimes that write `/tmp/jit-<pid>.dump` (Bun/JSC,
+    /// Java HotSpot, LuaJIT, etc.).
+    jit_tables: HashMap<u32, JitSymbolTable>,
 }
 
 impl Default for TraceHandler {
@@ -217,6 +222,7 @@ impl TraceHandler {
             symbolizer: Symbolizer::new(),
             cache: Default::default(),
             v8_readers: HashMap::new(),
+            jit_tables: HashMap::new(),
         }
     }
 
@@ -244,6 +250,7 @@ impl TraceHandler {
     pub fn invalidate_caches_for_pid(&mut self, tgid: u32) {
         self.cache.invalidate_pid(tgid);
         self.v8_readers.remove(&tgid);
+        self.jit_tables.remove(&tgid);
         tracing::debug!("invalidated symbol caches for pid {}", tgid);
     }
 
@@ -259,6 +266,32 @@ impl TraceHandler {
             data.version.2,
         );
         self.v8_readers.insert(tgid, V8HeapReader::new(tgid, data));
+    }
+
+    /// Register a JITDump symbol table for a process.
+    ///
+    /// Used for resolving JIT-compiled function names from runtimes
+    /// that write `/tmp/jit-<pid>.dump` (Bun/JSC, Java HotSpot, LuaJIT).
+    pub fn register_jit_table(&mut self, tgid: u32, table: JitSymbolTable) {
+        tracing::info!(
+            "registered JITDump symbol table for pid {} ({} symbols)",
+            tgid,
+            table.len(),
+        );
+        self.jit_tables.insert(tgid, table);
+    }
+
+    /// Check if a JITDump symbol table is registered for a process.
+    pub fn has_jit_table(&self, tgid: u32) -> bool {
+        self.jit_tables.contains_key(&tgid)
+    }
+
+    /// Get a mutable reference to the JITDump symbol table for a process.
+    ///
+    /// Used by streaming modes (TUI/serve) to incrementally reload
+    /// JITDump files for newly-compiled functions.
+    pub fn jit_table_mut(&mut self, tgid: u32) -> Option<&mut JitSymbolTable> {
+        self.jit_tables.get_mut(&tgid)
     }
 
     pub fn print_stats(&self) {
@@ -542,6 +575,23 @@ impl TraceHandler {
                             v8sym.function_name.clone()
                         };
                         user_syms[i].symbol = Some(display);
+                    }
+                }
+            }
+        }
+
+        // Override remaining [unknown] symbols using JITDump if available.
+        // JITDump provides address-to-symbol mappings for JIT-compiled code
+        // from runtimes like Bun (JSC), Java HotSpot, and LuaJIT.
+        // This runs after V8 SFI resolution: V8 heap reader takes priority
+        // for Node.js (richer data), JITDump is for non-V8 runtimes.
+        if let Some(jit_table) = self.jit_tables.get(&pid) {
+            for (i, sym) in user_syms.iter_mut().enumerate() {
+                if sym.symbol.as_deref() == Some("[unknown]") {
+                    if let Some(addr) = addrs.get(i) {
+                        if let Some(jit_sym) = jit_table.resolve(*addr) {
+                            sym.symbol = Some(jitdump::format_jit_symbol(jit_sym));
+                        }
                     }
                 }
             }

--- a/profile-bee/src/trace_handler.rs
+++ b/profile-bee/src/trace_handler.rs
@@ -145,6 +145,107 @@ fn is_v8_symbol(name: &str) -> bool {
     V8_PREFIXES.iter().any(|p| name.starts_with(p))
 }
 
+/// Demangle a Zig symbol name by stripping compiler-generated suffixes.
+///
+/// Zig symbols are already fairly human-readable (e.g. `io.reader.Reader.readAll`)
+/// but the compiler appends hash/type suffixes for internal disambiguation:
+///
+/// - `__anon_<hex>` — anonymous function/closure instantiation hash
+/// - `__struct_<hex>` — struct instantiation hash
+/// - `__<hex>` — trailing hex hash (generic instantiation, e.g. `func__a1b2c3d4`)
+///
+/// This function strips these suffixes when detected, returning `Some(cleaned)`
+/// if the name was modified, or `None` if it doesn't look like a Zig symbol.
+///
+/// No existing `zig-demangle` crate exists in the Rust ecosystem. OTel eBPF
+/// Profiler and Parca/LightSwitch have zero Zig-specific demangling code —
+/// they rely on standard C++/Rust demanglers only.
+fn demangle_zig(name: &str) -> Option<String> {
+    // Zig symbols use dots as namespace separators (e.g. `std.mem.Allocator.alloc`).
+    // C and C++ symbols don't contain dots (they use `::` or `_Z` mangling).
+    // Rust mangled symbols start with `_ZN` or `_R`. If the name doesn't
+    // contain a dot, it's unlikely to be a Zig symbol.
+    if !name.contains('.') {
+        return None;
+    }
+
+    // Also skip C++ mangled names that somehow contain dots
+    if name.starts_with("_Z") || name.starts_with("_R") {
+        return None;
+    }
+
+    let mut cleaned = name;
+
+    // Strip __anon_<hex> suffix
+    if let Some(pos) = cleaned.rfind("__anon_") {
+        let suffix = &cleaned[pos + 7..]; // after "__anon_"
+        if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_hexdigit()) {
+            cleaned = &cleaned[..pos];
+        }
+    }
+
+    // Strip __struct_<hex> suffix
+    if let Some(pos) = cleaned.rfind("__struct_") {
+        let suffix = &cleaned[pos + 9..]; // after "__struct_"
+        if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_hexdigit()) {
+            cleaned = &cleaned[..pos];
+        }
+    }
+
+    // Strip trailing __<hex> hash (generic instantiation suffix).
+    // Only match if the suffix after the last `__` is pure hex and
+    // at least 4 chars (to avoid false positives on short names).
+    if let Some(pos) = cleaned.rfind("__") {
+        let suffix = &cleaned[pos + 2..];
+        if suffix.len() >= 4 && suffix.bytes().all(|b| b.is_ascii_hexdigit()) {
+            cleaned = &cleaned[..pos];
+        }
+    }
+
+    if cleaned != name {
+        Some(cleaned.to_string())
+    } else {
+        None
+    }
+}
+
+/// Strip GCC/LLVM clone suffixes from symbol names.
+///
+/// Compilers append suffixes like `.cold`, `.constprop.0`, `.isra.0`,
+/// `.part.0`, `.clone.0`, and `.llvm.<hex>` to distinguish compiler-generated
+/// variants of functions. These are noise in profiler output.
+///
+/// Matches the approach used by OTel eBPF Profiler's `strip_clone_suffixes`.
+fn strip_clone_suffixes(name: &str) -> &str {
+    let mut result = name;
+    loop {
+        let prev = result;
+        for suffix in &[".cold", ".constprop", ".isra", ".part", ".clone"] {
+            if let Some(pos) = result.rfind(suffix) {
+                let after = &result[pos + suffix.len()..];
+                // Accept ".suffix" or ".suffix.N" where N is digits
+                if after.is_empty()
+                    || after.starts_with('.')
+                        && after[1..].bytes().all(|b| b.is_ascii_digit())
+                {
+                    result = &result[..pos];
+                }
+            }
+        }
+        // Strip .llvm.<hex> suffix
+        if let Some(pos) = result.rfind(".llvm.") {
+            let after = &result[pos + 6..];
+            if !after.is_empty() && after.bytes().all(|b| b.is_ascii_hexdigit()) {
+                result = &result[..pos];
+            }
+        }
+        if result == prev {
+            break;
+        }
+    }
+    result
+}
+
 pub struct SymbolFormatter;
 
 impl SymbolFormatter {
@@ -160,8 +261,9 @@ impl SymbolFormatter {
             }
         };
 
+        let name = strip_clone_suffixes(&sym.name);
         StackFrameInfo {
-            symbol: Some(format!("{}_k", sym.name)),
+            symbol: Some(format!("{}_k", name)),
             ..Default::default()
         }
     }
@@ -181,8 +283,10 @@ impl SymbolFormatter {
         let name = sym.name.to_string();
         let display_name = if is_v8_symbol(&name) {
             format_v8_symbol(&name).unwrap_or(name)
+        } else if let Some(demangled) = demangle_zig(&name) {
+            demangled
         } else {
-            name
+            strip_clone_suffixes(&name).to_string()
         };
 
         StackFrameInfo {
@@ -765,5 +869,94 @@ mod tests {
             format_short_source("node:internal/modules/cjs/loader.js"),
             "loader.js"
         );
+    }
+
+    // ── Zig demangling tests ──
+
+    #[test]
+    fn test_demangle_zig_anon_suffix() {
+        assert_eq!(
+            demangle_zig("io.reader.Reader.readAll__anon_abc123"),
+            Some("io.reader.Reader.readAll".to_string())
+        );
+    }
+
+    #[test]
+    fn test_demangle_zig_struct_suffix() {
+        assert_eq!(
+            demangle_zig("hash_map.HashMap.put__struct_5678abcd"),
+            Some("hash_map.HashMap.put".to_string())
+        );
+    }
+
+    #[test]
+    fn test_demangle_zig_hex_hash() {
+        assert_eq!(
+            demangle_zig("mem.Allocator.alloc__a1b2c3d4"),
+            Some("mem.Allocator.alloc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_demangle_zig_no_suffix() {
+        // Already clean Zig symbol — should return None
+        assert_eq!(demangle_zig("debug.dumpStackTrace"), None);
+    }
+
+    #[test]
+    fn test_demangle_zig_not_zig() {
+        // C symbol — no dots, should return None
+        assert_eq!(demangle_zig("malloc"), None);
+        // C++ mangled — should return None
+        assert_eq!(demangle_zig("_ZN3std4main"), None);
+        // Rust mangled — should return None
+        assert_eq!(demangle_zig("_RNvC3std4main"), None);
+    }
+
+    #[test]
+    fn test_demangle_zig_short_hex_not_stripped() {
+        // Only 2 hex chars after __ — too short, don't strip
+        assert_eq!(demangle_zig("std.io.read__ab"), None);
+    }
+
+    // ── Clone suffix stripping tests ──
+
+    #[test]
+    fn test_strip_clone_cold() {
+        assert_eq!(strip_clone_suffixes("func.cold"), "func");
+    }
+
+    #[test]
+    fn test_strip_clone_constprop() {
+        assert_eq!(strip_clone_suffixes("func.constprop.0"), "func");
+    }
+
+    #[test]
+    fn test_strip_clone_isra() {
+        assert_eq!(strip_clone_suffixes("func.isra.0"), "func");
+    }
+
+    #[test]
+    fn test_strip_clone_llvm() {
+        assert_eq!(strip_clone_suffixes("func.llvm.12345678"), "func");
+    }
+
+    #[test]
+    fn test_strip_clone_multiple() {
+        assert_eq!(
+            strip_clone_suffixes("func.constprop.0.isra.0"),
+            "func"
+        );
+    }
+
+    #[test]
+    fn test_strip_clone_none() {
+        assert_eq!(strip_clone_suffixes("normal_func"), "normal_func");
+    }
+
+    #[test]
+    fn test_strip_clone_preserves_name() {
+        // Don't strip if "cold" is part of the actual name
+        assert_eq!(strip_clone_suffixes("get_cold_data"), "get_cold_data");
     }
 }

--- a/profile-bee/src/trace_handler.rs
+++ b/profile-bee/src/trace_handler.rs
@@ -1,4 +1,5 @@
 use crate::ebpf::{FramePointersPod, StackInfoPod};
+use crate::jitdump::{self, JitSymbolTable};
 use crate::v8::{V8HeapReader, V8IntrospectionData};
 use crate::{cache::PointerStackFramesCache, types::StackFrameInfo, types::StackInfoExt};
 use aya::maps::MapData;
@@ -203,6 +204,10 @@ pub struct TraceHandler {
     /// V8 heap readers per PID, for resolving JavaScript function names
     /// from SFI pointers extracted by the eBPF V8 frame extractor.
     v8_readers: HashMap<u32, V8HeapReader>,
+    /// JITDump symbol tables per PID, for resolving JIT-compiled function
+    /// names from runtimes that write `/tmp/jit-<pid>.dump` (Bun/JSC,
+    /// Java HotSpot, LuaJIT, etc.).
+    jit_tables: HashMap<u32, JitSymbolTable>,
 }
 
 impl Default for TraceHandler {
@@ -217,6 +222,7 @@ impl TraceHandler {
             symbolizer: Symbolizer::new(),
             cache: Default::default(),
             v8_readers: HashMap::new(),
+            jit_tables: HashMap::new(),
         }
     }
 
@@ -244,6 +250,7 @@ impl TraceHandler {
     pub fn invalidate_caches_for_pid(&mut self, tgid: u32) {
         self.cache.invalidate_pid(tgid);
         self.v8_readers.remove(&tgid);
+        self.jit_tables.remove(&tgid);
         tracing::debug!("invalidated symbol caches for pid {}", tgid);
     }
 
@@ -259,6 +266,32 @@ impl TraceHandler {
             data.version.2,
         );
         self.v8_readers.insert(tgid, V8HeapReader::new(tgid, data));
+    }
+
+    /// Register a JITDump symbol table for a process.
+    ///
+    /// Used for resolving JIT-compiled function names from runtimes
+    /// that write `/tmp/jit-<pid>.dump` (Bun/JSC, Java HotSpot, LuaJIT).
+    pub fn register_jit_table(&mut self, tgid: u32, table: JitSymbolTable) {
+        tracing::info!(
+            "registered JITDump symbol table for pid {} ({} symbols)",
+            tgid,
+            table.len(),
+        );
+        self.jit_tables.insert(tgid, table);
+    }
+
+    /// Check if a JITDump symbol table is registered for a process.
+    pub fn has_jit_table(&self, tgid: u32) -> bool {
+        self.jit_tables.contains_key(&tgid)
+    }
+
+    /// Get a mutable reference to the JITDump symbol table for a process.
+    ///
+    /// Used by streaming modes (TUI/serve) to incrementally reload
+    /// JITDump files for newly-compiled functions.
+    pub fn jit_table_mut(&mut self, tgid: u32) -> Option<&mut JitSymbolTable> {
+        self.jit_tables.get_mut(&tgid)
     }
 
     pub fn print_stats(&self) {
@@ -554,6 +587,23 @@ impl TraceHandler {
                             v8sym.function_name.clone()
                         };
                         user_syms[i].symbol = Some(display);
+                    }
+                }
+            }
+        }
+
+        // Override remaining [unknown] symbols using JITDump if available.
+        // JITDump provides address-to-symbol mappings for JIT-compiled code
+        // from runtimes like Bun (JSC), Java HotSpot, and LuaJIT.
+        // This runs after V8 SFI resolution: V8 heap reader takes priority
+        // for Node.js (richer data), JITDump is for non-V8 runtimes.
+        if let Some(jit_table) = self.jit_tables.get(&pid) {
+            for (i, sym) in user_syms.iter_mut().enumerate() {
+                if sym.symbol.as_deref() == Some("[unknown]") {
+                    if let Some(addr) = addrs.get(i) {
+                        if let Some(jit_sym) = jit_table.resolve(*addr) {
+                            sym.symbol = Some(jitdump::format_jit_symbol(jit_sym));
+                        }
                     }
                 }
             }

--- a/profile-bee/src/trace_handler.rs
+++ b/profile-bee/src/trace_handler.rs
@@ -254,6 +254,15 @@ impl TraceHandler {
         tracing::debug!("invalidated symbol caches for pid {}", tgid);
     }
 
+    /// Invalidate the symbol resolution cache for a PID without removing
+    /// runtime-specific readers (V8, JITDump).
+    ///
+    /// Used when JIT symbols are reloaded — the cached stacks with `[unknown]`
+    /// entries need to be re-resolved, but the JIT table itself should be kept.
+    pub fn invalidate_symbol_cache_for_pid(&mut self, tgid: u32) {
+        self.cache.invalidate_pid(tgid);
+    }
+
     /// Register a V8 heap reader for a Node.js process.
     /// The reader uses the V8 introspection data to resolve SFI pointers
     /// from the eBPF V8 frame extractor to JavaScript function names.

--- a/tests/fixtures/src/bun_callstack.js
+++ b/tests/fixtures/src/bun_callstack.js
@@ -1,0 +1,52 @@
+// Bun test fixture for profile-bee E2E tests.
+// Creates a CPU-intensive call stack with known function names.
+//
+// Bun uses JavaScriptCore (not V8). When BUN_JSC_useJITDump=1 is set,
+// JSC writes /tmp/jit-<pid>.dump with address-to-symbol mappings for
+// JIT-compiled functions. profile-bee auto-injects this env var when
+// spawning Bun via `probee -- bun <script>`.
+//
+// The warmup phase ensures functions are JIT-compiled (and recorded in
+// the JITDump file) before the main profiling window.
+
+'use strict';
+
+function hot() {
+    // Busy loop to consume CPU time and be visible in profiles
+    let sum = 0;
+    for (let i = 0; i < 1e6; i++) {
+        sum += Math.sqrt(i) * Math.sin(i);
+    }
+    return sum;
+}
+
+function processData() {
+    return hot();
+}
+
+function handleRequest() {
+    return processData();
+}
+
+function serverLoop() {
+    return handleRequest();
+}
+
+// Warmup: call enough times to trigger JIT compilation in JSC.
+// JSC's DFG JIT compiles after ~100 invocations, FTL after ~1000.
+for (let i = 0; i < 100; i++) {
+    serverLoop();
+}
+
+// Run for a fixed duration to give the profiler time to capture samples
+const duration = parseInt(process.env.DURATION_MS || '2000', 10);
+const start = Date.now();
+let result = 0;
+while (Date.now() - start < duration) {
+    result += serverLoop();
+}
+
+// Prevent dead code elimination
+if (result === Infinity) {
+    console.log(result);
+}

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -569,6 +569,100 @@ test_nodejs_dwarf_callstack() {
         "Should contain JS function names or V8 internal frames with DWARF"
 }
 
+# ---------- Bun / JITDump tests ---------------------------------------------
+
+# Run the profiler against a Bun script with JITDump support.
+# Uses -- <command> syntax so setup_process_to_profile auto-injects
+# BUN_JSC_useJITDump=1.
+run_bun_profiler() {
+    local script="$1"
+    local name="$2"
+    shift 2
+    local extra_args=("$@")
+    local collapse_file="$OUTPUT_DIR/${name}.collapse"
+
+    # Remove any stale collapse file so the existence check below
+    # verifies that the profiler actually produced fresh output.
+    rm -f "$collapse_file"
+
+    local profiler_output
+    profiler_output=$(DURATION_MS=$((PROFILE_TIME_MS + 500)) timeout "$TEST_TIMEOUT" "$PROFILER" \
+        --time "$PROFILE_TIME_MS" \
+        --frequency "$FREQUENCY" \
+        --collapse "$collapse_file" \
+        --skip-idle \
+        "${extra_args[@]+"${extra_args[@]}"}" \
+        -- bun "$script" 2>&1) || true
+
+    if [[ "$VERBOSE" == "true" ]]; then
+        echo "--- profiler output ---" >&2
+        echo "$profiler_output" >&2
+        echo "--- end ---" >&2
+    fi
+
+    if [[ ! -f "$collapse_file" ]]; then
+        echo "Collapse file not created: $collapse_file" >&2
+        return 1
+    fi
+
+    echo "$collapse_file"
+}
+
+test_bun_samples_collected() {
+    if ! command -v bun &>/dev/null; then
+        echo "  SKIP: bun not found in PATH" >&2
+        return 0
+    fi
+
+    local script="$SCRIPT_DIR/fixtures/src/bun_callstack.js"
+    if [[ ! -f "$script" ]]; then
+        echo "  SKIP: fixture $script not found" >&2
+        return 0
+    fi
+
+    local file
+    file=$(run_bun_profiler "$script" "bun-samples")
+
+    local total
+    total=$(count_samples "$file")
+    if [[ "$total" -gt 0 ]]; then
+        return 0
+    else
+        echo "  No samples collected for Bun (total=$total)" >&2
+        return 1
+    fi
+}
+
+test_bun_jitdump_callstack() {
+    if ! command -v bun &>/dev/null; then
+        echo "  SKIP: bun not found in PATH" >&2
+        return 0
+    fi
+
+    local script="$SCRIPT_DIR/fixtures/src/bun_callstack.js"
+    if [[ ! -f "$script" ]]; then
+        echo "  SKIP: fixture $script not found" >&2
+        return 0
+    fi
+
+    local file
+    file=$(run_bun_profiler "$script" "bun-jitdump-callstack")
+
+    local total
+    total=$(count_samples "$file")
+    if [[ "$total" -le 0 ]]; then
+        echo "  No samples collected for Bun" >&2
+        return 1
+    fi
+
+    # Check for JS function names from JITDump (primary goal).
+    # JIT-compiled functions should appear with their JS names.
+    # Also accept Bun/JSC internal frames as proof that stack walking works.
+    assert_stack_contains "$file" \
+        "hot\|processData\|handleRequest\|serverLoop" \
+        "Should contain JS function names from JITDump"
+}
+
 # ── Run all tests ────────────────────────────────────────────────────────────
 
 echo ""
@@ -620,6 +714,11 @@ echo "── Node.js / JIT Runtime ──"
 run_test "Node.js samples collected"                 test_nodejs_samples_collected
 run_test "Node.js JS function names in stacks"       test_nodejs_callstack
 run_test "Node.js DWARF + FP-only JIT zones"         test_nodejs_dwarf_callstack
+echo ""
+
+echo "── Bun / JITDump ──"
+run_test "Bun samples collected"                     test_bun_samples_collected
+run_test "Bun JS function names via JITDump"         test_bun_jitdump_callstack
 echo ""
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -608,31 +608,6 @@ run_bun_profiler() {
     echo "$collapse_file"
 }
 
-test_bun_samples_collected() {
-    if ! command -v bun &>/dev/null; then
-        echo "  SKIP: bun not found in PATH" >&2
-        return 0
-    fi
-
-    local script="$SCRIPT_DIR/fixtures/src/bun_callstack.js"
-    if [[ ! -f "$script" ]]; then
-        echo "  SKIP: fixture $script not found" >&2
-        return 0
-    fi
-
-    local file
-    file=$(run_bun_profiler "$script" "bun-samples")
-
-    local total
-    total=$(count_samples "$file")
-    if [[ "$total" -gt 0 ]]; then
-        return 0
-    else
-        echo "  No samples collected for Bun (total=$total)" >&2
-        return 1
-    fi
-}
-
 test_bun_jitdump_callstack() {
     if ! command -v bun &>/dev/null; then
         echo "  SKIP: bun not found in PATH" >&2
@@ -648,19 +623,20 @@ test_bun_jitdump_callstack() {
     local file
     file=$(run_bun_profiler "$script" "bun-jitdump-callstack")
 
+    # Basic sanity: we should collect a non-zero number of samples
     local total
     total=$(count_samples "$file")
     if [[ "$total" -le 0 ]]; then
-        echo "  No samples collected for Bun" >&2
+        echo "  No samples collected for Bun (total=$total)" >&2
         return 1
     fi
 
     # Check for JS function names from JITDump (primary goal).
-    # JIT-compiled functions should appear with their JS names.
-    # Also accept Bun/JSC internal frames as proof that stack walking works.
+    # JSC emits JITDump symbols like "JSC-FTL: hot#..." or "JSC-DFG: processData#..."
+    # We look for our fixture function names prefixed with JSC JIT tier markers.
     assert_stack_contains "$file" \
-        "hot\|processData\|handleRequest\|serverLoop" \
-        "Should contain JS function names from JITDump"
+        "JSC.*\bhot\b\|JSC.*\bprocessData\b\|JSC.*\bhandleRequest\b\|JSC.*\bserverLoop\b" \
+        "Should contain JSC JIT-compiled JS function names from JITDump"
 }
 
 # ── Run all tests ────────────────────────────────────────────────────────────
@@ -717,7 +693,6 @@ run_test "Node.js DWARF + FP-only JIT zones"         test_nodejs_dwarf_callstack
 echo ""
 
 echo "── Bun / JITDump ──"
-run_test "Bun samples collected"                     test_bun_samples_collected
 run_test "Bun JS function names via JITDump"         test_bun_jitdump_callstack
 echo ""
 

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -632,7 +632,8 @@ test_bun_jitdump_callstack() {
     fi
 
     # Check for JS function names from JITDump (primary goal).
-    # JSC emits JITDump symbols like "JSC-FTL: hot#..." or "JSC-DFG: processData#..."
+    # JSC emits JITDump symbols like "JSC-FTL: hot" or "JSC-DFG: processData"
+    # (JSC hash suffixes like #DdCypB are stripped during formatting).
     # We look for our fixture function names prefixed with JSC JIT tier markers.
     assert_stack_contains "$file" \
         "JSC.*\bhot\b\|JSC.*\bprocessData\b\|JSC.*\bhandleRequest\b\|JSC.*\bserverLoop\b" \


### PR DESCRIPTION
Given that I'm using bunjs more often than nodejs makes sense to have this supported...

Add a JITDump binary format parser that resolves JIT-compiled JavaScript function names from runtimes like Bun (JavaScriptCore), Java HotSpot, and LuaJIT. Without this, JIT code in anonymous mmap'd pages shows as [unknown].

Implementation:
- New jitdump.rs: zero-dependency parser with BTreeMap for O(log n) address range lookups, incremental reload for streaming modes, tolerates truncated files. Handles JIT_CODE_LOAD, JIT_CODE_MOVE, JIT_CODE_DEBUG_INFO, and JIT_CODE_CLOSE records. Discovers both standard (jit-<pid>.dump) and JSC (jit-<tid>-<pid>-<random>) file naming conventions.
- trace_handler.rs: JIT tables per PID, override [unknown] symbols after V8 SFI resolution (V8 takes priority for Node.js, JITDump for non-V8).
- event_loop.rs: auto-load JITDump on new PID detection, reload at end of each collection window to catch symbols written during profiling.
- spawn.rs: auto-detect bun/bunx and inject BUN_JSC_useJITDump=1.
- profile-bee.rs: warn when --pid targets Bun without JITDump file.
- symbolize.rs: JITDump override in offline re-symbolization path.
- E2E tests: bun_callstack.js fixture + 2 tests verifying sample collection and JS function name resolution via JITDump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JITDump parsing and per-process JIT symbol resolution to enhance profiling output for Bun/JavaScriptCore.
  * Added automatic Bun JITDump detection, including guidance to restart Bun with `BUN_JSC_useJITDump=1` when symbol support is missing.
  * Added streaming/incremental JITDump reloading so newly written symbols appear in symbolized stacks.
* **Improvements**
  * Improved display of non-V8 user symbols, including Zig demangling and clone-suffix cleanup.
* **Tests**
  * Added Bun + JITDump end-to-end coverage and fixtures to verify resolved JIT function names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->