### PR TITLE
Add kernel/softirq/interrupt context labels to stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.3.14
+
+### Improvements
+
+- **Kernel/softirq/interrupt context labels** — stack traces are now annotated with execution context labels (`softirq:net_rx_k`, `interrupt:timer_k`, etc.) when kernel frames match known softirq handlers or interrupt vectors. This makes softirq and interrupt CPU time visually identifiable in flamegraphs.
+- **Softirq classification** — identifies specific softirq handlers: NET_RX, NET_TX, TIMER, HRTIMER, TASKLET, BLOCK, BLOCK_IOPOLL, RCU, and SCHED (`run_rebalance_domains`).
+- **Interrupt classification** — identifies APIC timer, reschedule IPI, call_function, irq_work, thermal, and generic hardware interrupts.
+- **Priority-based labeling** — specific softirq > generic softirq > interrupt, ensuring the most informative label is selected.
+- **Kernel-only frame scanning** — context classification only inspects kernel frames (identified by `_k` suffix), avoiding false-positives from userspace symbols.
+- **Broad kernel version support** — covers both modern (`handle_softirqs`, kernel >= 5.19) and legacy (`__do_softirq`) softirq entry symbols.
+
 ## v0.3.13
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Profile Bee is an eBPF-based CPU profiler that ships as a single binary — no BCC, libbpf, or perf tooling needed on the target host. Built with Rust and [aya](https://aya-rs.dev/).
 
+```bash
+curl -fsSL https://raw.githubusercontent.com/zz85/profile-bee/main/install.sh | bash
+```
+
 ![Architecture](https://raw.githubusercontent.com/zz85/profile-bee/main/docs/architecture-sketch.png)
 
 - Just `cargo install`, `sudo probee --tui`, and you're looking at a live flamegraph — no package manager dance, no Python dependencies, no separate visualization step
@@ -28,12 +32,6 @@ Download and install the latest release with a single command:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/zz85/profile-bee/main/install.sh | bash
-```
-
-Or with wget:
-
-```bash
-wget -qO- https://raw.githubusercontent.com/zz85/profile-bee/main/install.sh | bash
 ```
 
 This installs pre-built binaries to `~/.local/bin`. No Rust toolchain required.

--- a/install.sh
+++ b/install.sh
@@ -136,12 +136,9 @@ verify_installation() {
         echo ""
         echo -e "${GREEN}Installation verified!${NC}"
         echo ""
-        echo "Run 'probee --help' to get started"
-        echo "Note: profile-bee requires root privileges to run (uses eBPF)"
-        echo ""
         echo "Quick start:"
-        echo "  sudo probee --tui              # Interactive TUI flamegraph"
-        echo "  sudo probee --svg out.svg      # Generate SVG flamegraph"
+        echo "  sudo ${INSTALL_DIR}/probee --tui              # Interactive TUI flamegraph"
+        echo "  sudo ${INSTALL_DIR}/probee -o out.svg         # Generate SVG flamegraph"
         echo ""
         return 0
     else

--- a/profile-bee/Cargo.toml
+++ b/profile-bee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile-bee"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2021"
 license = "MIT"
 description = "eBPF-based CPU profiler with flamegraph generation, DWARF unwinding, and interactive TUI"

--- a/profile-bee/bin/profile-bee.rs
+++ b/profile-bee/bin/profile-bee.rs
@@ -1681,7 +1681,7 @@ fn spawn_profiling_thread(
                         .collect::<Vec<_>>()
                         .join(";");
                     let count = frames.count;
-                    format!("{} {}", &key, count)
+                    format!("{} {}", key, count)
                 })
                 .collect::<Vec<_>>();
             out.sort();

--- a/profile-bee/src/event_loop.rs
+++ b/profile-bee/src/event_loop.rs
@@ -569,7 +569,7 @@ impl ProfilingEventLoop {
                     .map(|s| s.fmt_symbol())
                     .collect::<Vec<_>>()
                     .join(";");
-                format!("{} {}", &key, frames.count)
+                format!("{} {}", key, frames.count)
             })
             .collect();
         out.sort();
@@ -700,7 +700,7 @@ where
         .iter()
         .map(|fc| {
             let key = fc.frames.iter().map(&fmt).collect::<Vec<_>>().join(";");
-            format!("{} {}", &key, fc.count)
+            format!("{} {}", key, fc.count)
         })
         .collect();
     out.sort();

--- a/profile-bee/src/trace_handler.rs
+++ b/profile-bee/src/trace_handler.rs
@@ -165,6 +165,100 @@ impl SymbolFormatter {
         }
     }
 
+    fn kernel_symbol_name(frame: &StackFrameInfo) -> Option<&str> {
+        frame
+            .symbol
+            .as_deref()
+            .and_then(|sym| sym.strip_suffix("_k"))
+    }
+
+    fn classify_softirq_symbol(symbol: &str) -> Option<&'static str> {
+        match symbol {
+            "net_rx_action" => Some("softirq:net_rx_k"),
+            "net_tx_action" => Some("softirq:net_tx_k"),
+            "run_timer_softirq" => Some("softirq:timer_k"),
+            "hrtimer_run_softirq" => Some("softirq:hrtimer_k"),
+            "tasklet_action" => Some("softirq:tasklet_k"),
+            "tasklet_hi_action" => Some("softirq:tasklet_hi_k"),
+            "blk_done_softirq" => Some("softirq:block_k"),
+            "blk_iopoll_softirq" | "irq_poll_softirq" => Some("softirq:block_iopoll_k"),
+            "rcu_core_si" | "rcu_process_callbacks" => Some("softirq:rcu_k"),
+            "run_rebalance_domains" => Some("softirq:sched_k"),
+            _ => None,
+        }
+    }
+
+    fn is_generic_softirq_symbol(symbol: &str) -> bool {
+        matches!(
+            symbol,
+            "__softirqentry_text_start"
+                | "__do_softirq"
+                | "handle_softirqs"
+                | "do_softirq"
+                | "run_ksoftirqd"
+        )
+    }
+
+    fn classify_interrupt_symbol(symbol: &str) -> Option<&'static str> {
+        match symbol {
+            "sysvec_apic_timer_interrupt"
+            | "asm_sysvec_apic_timer_interrupt"
+            | "local_apic_timer_interrupt" => Some("interrupt:timer_k"),
+            "sysvec_reschedule_ipi" | "asm_sysvec_reschedule_ipi" => {
+                Some("interrupt:reschedule_ipi_k")
+            }
+            "sysvec_call_function_single" | "sysvec_call_function_single_interrupt" => {
+                Some("interrupt:call_function_single_k")
+            }
+            "sysvec_call_function" | "sysvec_call_function_interrupt" => {
+                Some("interrupt:call_function_k")
+            }
+            "sysvec_irq_work" => Some("interrupt:irq_work_k"),
+            "sysvec_thermal" => Some("interrupt:thermal_k"),
+            "sysvec_error_interrupt" => Some("interrupt:error_k"),
+            "sysvec_spurious_apic_interrupt" => Some("interrupt:spurious_k"),
+            "common_interrupt"
+            | "__common_interrupt"
+            | "asm_common_interrupt"
+            | "handle_irq_event"
+            | "handle_irq_event_percpu"
+            | "__handle_irq_event_percpu"
+            | "handle_edge_irq"
+            | "handle_level_irq"
+            | "__handle_domain_irq"
+            | "do_IRQ" => Some("interrupt_k"),
+            _ => None,
+        }
+    }
+
+    fn infer_kernel_context_label(kernel_syms: &[StackFrameInfo]) -> Option<&'static str> {
+        for frame in kernel_syms {
+            if let Some(symbol) = Self::kernel_symbol_name(frame) {
+                if let Some(label) = Self::classify_softirq_symbol(symbol) {
+                    return Some(label);
+                }
+            }
+        }
+
+        for frame in kernel_syms {
+            if let Some(symbol) = Self::kernel_symbol_name(frame) {
+                if Self::is_generic_softirq_symbol(symbol) {
+                    return Some("softirq_k");
+                }
+            }
+        }
+
+        for frame in kernel_syms {
+            if let Some(symbol) = Self::kernel_symbol_name(frame) {
+                if let Some(label) = Self::classify_interrupt_symbol(symbol) {
+                    return Some(label);
+                }
+            }
+        }
+
+        None
+    }
+
     /// Symbol name with V8 perf-map formatting applied when detected.
     fn map_user_sym_to_stack(sym: Symbolized) -> StackFrameInfo {
         let sym = match sym {
@@ -570,7 +664,17 @@ impl TraceHandler {
             frame.address = addr;
         }
 
+        // Infer context label from kernel frames only (before combining) to avoid
+        // false-positives from userspace symbols that happen to end in `_k`.
+        let context_label = SymbolFormatter::infer_kernel_context_label(&kernel_syms);
+
         let mut combined = kernel_syms.into_iter().chain(user_syms).collect::<Vec<_>>();
+        if let Some(label) = context_label {
+            combined.push(StackFrameInfo {
+                symbol: Some(label.to_string()),
+                ..Default::default()
+            });
+        }
 
         let pid_info = StackFrameInfo::process_only(stack_info);
         combined.push(pid_info);
@@ -705,6 +809,96 @@ mod tests {
         assert_eq!(
             format_short_source("node:internal/modules/cjs/loader.js"),
             "loader.js"
+        );
+    }
+
+    fn kernel_frame(symbol: &str) -> StackFrameInfo {
+        StackFrameInfo {
+            symbol: Some(symbol.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_prefers_softirq() {
+        let frames = vec![
+            kernel_frame("common_interrupt_k"),
+            kernel_frame("__softirqentry_text_start_k"),
+            kernel_frame("net_rx_action_k"),
+        ];
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&frames),
+            Some("softirq:net_rx_k")
+        );
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_detects_interrupt() {
+        let frames = vec![
+            kernel_frame("asm_sysvec_apic_timer_interrupt_k"),
+            kernel_frame("scheduler_tick_k"),
+        ];
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&frames),
+            Some("interrupt:timer_k")
+        );
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_none_for_regular_kernel_stack() {
+        let frames = vec![
+            kernel_frame("finish_task_switch_k"),
+            kernel_frame("schedule_k"),
+        ];
+        assert_eq!(SymbolFormatter::infer_kernel_context_label(&frames), None);
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_do_softirq_legacy() {
+        // __do_softirq is the older kernel name (pre-5.19)
+        let frames = vec![
+            kernel_frame("__do_softirq_k"),
+            kernel_frame("some_handler_k"),
+        ];
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&frames),
+            Some("softirq_k")
+        );
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_sched_softirq() {
+        let frames = vec![
+            kernel_frame("handle_softirqs_k"),
+            kernel_frame("run_rebalance_domains_k"),
+        ];
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&frames),
+            Some("softirq:sched_k")
+        );
+    }
+
+    #[test]
+    fn test_infer_kernel_context_label_ignores_userspace_frames() {
+        // A userspace function that happens to end in _k should NOT trigger
+        // classification when only kernel frames are passed.
+        let user_frames = vec![kernel_frame("net_rx_action_k")];
+        // If this were mistakenly passed with user frames mixed in, it would
+        // match. But since we now only pass kernel_syms, this test validates
+        // the function works correctly on kernel-only input.
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&user_frames),
+            Some("softirq:net_rx_k")
+        );
+
+        // Frames without _k suffix (actual userspace symbols) are ignored
+        let user_only = vec![StackFrameInfo {
+            symbol: Some("net_rx_action".to_string()),
+            ..Default::default()
+        }];
+        assert_eq!(
+            SymbolFormatter::infer_kernel_context_label(&user_only),
+            None
         );
     }
 }


### PR DESCRIPTION
Annotate flamegraph stacks with execution context (softirq, interrupt) by scanning kernel frames for known handler symbols. This makes it possible to visually identify and account for CPU time spent in softirq and interrupt context per process.

- Classify specific softirq handlers (NET_RX/TX, TIMER, RCU, SCHED, etc.)
- Classify interrupt vectors (APIC timer, IPI, common_interrupt, etc.)
- Priority: specific softirq > generic softirq > interrupt
- Only scan kernel frames (avoid userspace false-positives)
- Cover both modern (handle_softirqs) and legacy (__do_softirq) symbols

Addresses #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stack traces now include inferred kernel execution context labels, such as interrupt or softirq context, when applicable.
  * Context labels are derived from recognized kernel frames and displayed alongside trace information.

* **Bug Fixes**
  * Improved classification accuracy by prioritizing softirq context and ignoring userspace-like symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->